### PR TITLE
Postgres schema and ORM structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --reload
 ```
 
+### Backend with Docker
+```bash
+cd backend
+docker compose up --build
+```
+
+The API will be available on `http://localhost:8000` and PostgreSQL on `localhost:5432`.
+
 ### Services
 The `face_recog_local.py` service handles face recognition tasks.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/persistent_memory
+EMBEDDING_DIMENSION=512
+DB_ECHO=false

--- a/backend/DB_STRUCTURE.md
+++ b/backend/DB_STRUCTURE.md
@@ -1,0 +1,60 @@
+# Database Structure
+
+## Table Structure
+
+### Person
+- `id` - UUID primary key
+- `user_id` - owner of this person record; links to `User`
+- `name` - (`first_name`, `last_name`, `display_name`)
+- `facts` - stored in `PersonFact`
+- `dialogues` - linked through `Episodes`
+- `face` - vector representation of facial features for recognition (`face_embedding`)
+- `voice` - vector representation of vocal features for recognition (`voice_embedding`)
+- `face_embedding_model` - model/version used to generate the face embedding
+- `voice_embedding_model` - model/version used to generate the voice embedding
+- `last_seen_at` - timestamp of the most recent known interaction
+- `created_at` - timestamp when the person record was created
+- `updated_at` - timestamp when the person record was last updated
+
+### PersonFact
+- `id` - UUID primary key
+- `person_id` - links to `Person`
+- `fact_text` - remembered fact about the person
+- `source` - optional source label for where the fact came from
+- `source_episode_id` - optional link to the `Episode` where the fact was learned
+- `confidence` - optional confidence score for the fact
+- `created_at` - timestamp when the fact was created
+- `updated_at` - timestamp when the fact was last updated
+
+### Episodes
+- `id` - UUID primary key
+- `start_time` - timestamp of conversation start
+- `end_time` - timestamp of conversation end; nullable for in-progress conversations
+- `dialogue_summary` - summary of conversation
+- `summary_version` - optional version/model tag for the summary
+- `importance_score` - optional score for ranking memorable conversations
+- `user` - person wearing the glasses; links to `User`
+- `person` - person talking to; links to `Person`
+- `created_at` - timestamp when the episode record was created
+- `updated_at` - timestamp when the episode record was last updated
+
+### User
+- `id` - UUID primary key
+- `name` - (`first_name`, `last_name`, `display_name`)
+- `username` - unique application username
+- `oauth_provider` - optional OAuth provider name
+- `oauth_subject` - optional OAuth subject/identifier from the provider
+- `facts` - stored in `UserFact`
+- `preferences` - JSON object of user settings/preferences
+- `dialogues` - linked through `Episodes`
+- `created_at` - timestamp when the user record was created
+- `updated_at` - timestamp when the user record was last updated
+
+### UserFact
+- `id` - UUID primary key
+- `user_id` - links to `User`
+- `fact_text` - remembered fact about the user
+- `source` - optional source label for where the fact came from
+- `confidence` - optional confidence score for the fact
+- `created_at` - timestamp when the fact was created
+- `updated_at` - timestamp when the fact was last updated

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM pgvector/pgvector:pg16
+
+ENV POSTGRES_DB=persistent_memory
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_PASSWORD=postgres
+
+EXPOSE 5432

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = %(here)s/alembic
+prepend_sys_path = %(here)s
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@localhost:5432/persistent_memory
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import get_settings
+from app.core.database import Base
+from app.models import Episode, Person, PersonFact, User, UserFact
+
+config = context.config
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.database_url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/20260309_0001_initial_memory_schema.py
+++ b/backend/alembic/versions/20260309_0001_initial_memory_schema.py
@@ -1,0 +1,145 @@
+"""Initial persistent memory schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.dialects import postgresql
+
+from app.core.config import get_settings
+
+settings = get_settings()
+
+# revision identifiers, used by Alembic.
+revision = "20260309_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "users",
+        sa.Column("first_name", sa.String(length=100), nullable=False),
+        sa.Column("last_name", sa.String(length=100), nullable=False),
+        sa.Column("display_name", sa.String(length=200), nullable=True),
+        sa.Column("username", sa.String(length=100), nullable=False),
+        sa.Column("oauth_provider", sa.String(length=100), nullable=True),
+        sa.Column("oauth_subject", sa.String(length=255), nullable=True),
+        sa.Column(
+            "preferences",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_users")),
+        sa.UniqueConstraint("oauth_provider", "oauth_subject", name="uq_users_oauth_identity"),
+    )
+    op.create_index(op.f("ix_users_username"), "users", ["username"], unique=True)
+
+    op.create_table(
+        "people",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("first_name", sa.String(length=100), nullable=False),
+        sa.Column("last_name", sa.String(length=100), nullable=False),
+        sa.Column("display_name", sa.String(length=200), nullable=True),
+        sa.Column("face_embedding", Vector(dim=settings.embedding_dimension), nullable=True),
+        sa.Column("voice_embedding", Vector(dim=settings.embedding_dimension), nullable=True),
+        sa.Column("face_embedding_model", sa.String(length=100), nullable=True),
+        sa.Column("voice_embedding_model", sa.String(length=100), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_people_user_id_users"), ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_people")),
+    )
+    op.create_index(op.f("ix_people_user_id"), "people", ["user_id"], unique=False)
+    op.create_index(op.f("ix_people_last_seen_at"), "people", ["last_seen_at"], unique=False)
+
+    op.create_table(
+        "episodes",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("person_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("dialogue_summary", sa.Text(), nullable=False),
+        sa.Column("summary_version", sa.String(length=100), nullable=True),
+        sa.Column("importance_score", sa.Numeric(precision=4, scale=3), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["person_id"], ["people.id"], name=op.f("fk_episodes_person_id_people"), ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_episodes_user_id_users"), ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_episodes")),
+    )
+    op.create_index(op.f("ix_episodes_person_id"), "episodes", ["person_id"], unique=False)
+    op.create_index(op.f("ix_episodes_person_id_start_time"), "episodes", ["person_id", "start_time"], unique=False)
+    op.create_index(op.f("ix_episodes_user_id"), "episodes", ["user_id"], unique=False)
+    op.create_index(op.f("ix_episodes_user_id_start_time"), "episodes", ["user_id", "start_time"], unique=False)
+
+    op.create_table(
+        "person_facts",
+        sa.Column("person_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_episode_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("fact_text", sa.Text(), nullable=False),
+        sa.Column("source", sa.String(length=255), nullable=True),
+        sa.Column("confidence", sa.Numeric(precision=4, scale=3), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["person_id"], ["people.id"], name=op.f("fk_person_facts_person_id_people"), ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["source_episode_id"],
+            ["episodes.id"],
+            name=op.f("fk_person_facts_source_episode_id_episodes"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_person_facts")),
+    )
+    op.create_index(op.f("ix_person_facts_person_id"), "person_facts", ["person_id"], unique=False)
+    op.create_index(op.f("ix_person_facts_source_episode_id"), "person_facts", ["source_episode_id"], unique=False)
+
+    op.create_table(
+        "user_facts",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("fact_text", sa.Text(), nullable=False),
+        sa.Column("source", sa.String(length=255), nullable=True),
+        sa.Column("confidence", sa.Numeric(precision=4, scale=3), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_user_facts_user_id_users"), ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_facts")),
+    )
+    op.create_index(op.f("ix_user_facts_user_id"), "user_facts", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_user_facts_user_id"), table_name="user_facts")
+    op.drop_table("user_facts")
+
+    op.drop_index(op.f("ix_person_facts_source_episode_id"), table_name="person_facts")
+    op.drop_index(op.f("ix_person_facts_person_id"), table_name="person_facts")
+    op.drop_table("person_facts")
+
+    op.drop_index(op.f("ix_episodes_user_id_start_time"), table_name="episodes")
+    op.drop_index(op.f("ix_episodes_user_id"), table_name="episodes")
+    op.drop_index(op.f("ix_episodes_person_id_start_time"), table_name="episodes")
+    op.drop_index(op.f("ix_episodes_person_id"), table_name="episodes")
+    op.drop_table("episodes")
+
+    op.drop_index(op.f("ix_people_last_seen_at"), table_name="people")
+    op.drop_index(op.f("ix_people_user_id"), table_name="people")
+    op.drop_table("people")
+
+    op.drop_index(op.f("ix_users_username"), table_name="users")
+    op.drop_table("users")
+
+    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/backend/alembic/versions/__init__.py
+++ b/backend/alembic/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic revision package."""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package."""

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package."""

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,9 @@
+from collections.abc import Generator
+
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    yield from get_db()

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,3 @@
+from . import user as users
+
+__all__ = ["users"]

--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    app_name: str = "Persistent Memory"
+    database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/persistent_memory"
+    embedding_dimension: int = 512
+    db_echo: bool = False
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from uuid import UUID as UUIDType
+from uuid import uuid4
+
+from sqlalchemy import DateTime, MetaData, create_engine
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, declared_attr, mapped_column, sessionmaker
+
+from app.core.config import get_settings
+
+settings = get_settings()
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
+
+    @declared_attr.directive
+    def __tablename__(cls) -> str:
+        return cls.__name__.lower()
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
+class UUIDPrimaryKeyMixin:
+    id: Mapped[UUIDType] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+
+
+engine = create_engine(
+    settings.database_url,
+    echo=settings.db_echo,
+    future=True,
+)
+
+SessionLocal = sessionmaker(
+    bind=engine,
+    class_=Session,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
-from app.api.routes import users
 
-app = FastAPI()
+from app.api.routes import users
+from app.core.config import get_settings
+
+settings = get_settings()
+
+app = FastAPI(title=settings.app_name)
 
 app.include_router(users.router, prefix="/users", tags=["users"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,11 @@
+from app.models.episode import Episode
+from app.models.person import Person, PersonFact
+from app.models.user import User, UserFact
+
+__all__ = [
+    "Episode",
+    "Person",
+    "PersonFact",
+    "User",
+    "UserFact",
+]

--- a/backend/app/models/episode.py
+++ b/backend/app/models/episode.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Index, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.models.person import Person, PersonFact
+    from app.models.user import User
+
+
+class Episode(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "episodes"
+    __table_args__ = (
+        Index("ix_episodes_user_id_start_time", "user_id", "start_time"),
+        Index("ix_episodes_person_id_start_time", "person_id", "start_time"),
+    )
+
+    user_id: Mapped[Any] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    person_id: Mapped[Any] = mapped_column(
+        ForeignKey("people.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    end_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    dialogue_summary: Mapped[str] = mapped_column(Text, nullable=False)
+    summary_version: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    importance_score: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+
+    user: Mapped["User"] = relationship(back_populates="episodes")
+    person: Mapped["Person"] = relationship(back_populates="episodes")
+    introduced_facts: Mapped[list["PersonFact"]] = relationship(back_populates="source_episode")

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from typing import TYPE_CHECKING
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.config import get_settings
+from app.core.database import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+settings = get_settings()
+
+if TYPE_CHECKING:
+    from app.models.episode import Episode
+    from app.models.user import User
+
+
+class Person(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "people"
+
+    user_id: Mapped[Any] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    face_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(settings.embedding_dimension),
+        nullable=True,
+    )
+    voice_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(settings.embedding_dimension),
+        nullable=True,
+    )
+    face_embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    voice_embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        index=True,
+    )
+
+    owner: Mapped["User"] = relationship(back_populates="people")
+    facts: Mapped[list["PersonFact"]] = relationship(
+        back_populates="person",
+        cascade="all, delete-orphan",
+    )
+    episodes: Mapped[list["Episode"]] = relationship(
+        back_populates="person",
+        cascade="all, delete-orphan",
+    )
+
+
+class PersonFact(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "person_facts"
+
+    person_id: Mapped[Any] = mapped_column(
+        ForeignKey("people.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source_episode_id: Mapped[Any | None] = mapped_column(
+        ForeignKey("episodes.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    fact_text: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+
+    person: Mapped["Person"] = relationship(back_populates="facts")
+    source_episode: Mapped["Episode"] = relationship(back_populates="introduced_facts")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.models.episode import Episode
+    from app.models.person import Person
+
+
+class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint("oauth_provider", "oauth_subject", name="uq_users_oauth_identity"),
+    )
+
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    username: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    oauth_provider: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    oauth_subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    preferences: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+
+    facts: Mapped[list["UserFact"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    episodes: Mapped[list["Episode"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    people: Mapped[list["Person"]] = relationship(
+        back_populates="owner",
+        cascade="all, delete-orphan",
+    )
+
+
+class UserFact(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "user_facts"
+
+    user_id: Mapped[Any] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    fact_text: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(4, 3), nullable=True)
+
+    user: Mapped["User"] = relationship(back_populates="facts")

--- a/backend/app/schema/__init__.py
+++ b/backend/app/schema/__init__.py
@@ -1,0 +1,1 @@
+"""Schema package."""

--- a/backend/app/schema/user.py
+++ b/backend/app/schema/user.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UserFactRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    fact_text: str
+    source: str | None = None
+    confidence: Decimal | None = None
+
+
+class UserRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    first_name: str
+    last_name: str
+    display_name: str | None = None
+    username: str
+    preferences: dict = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+    facts: list[UserFactRead] = Field(default_factory=list)

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  db:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: persistent-memory-db
+    environment:
+      POSTGRES_DB: persistent_memory
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d persistent_memory"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    image: python:3.12-slim
+    container_name: persistent-memory-api
+    working_dir: /app
+    environment:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@db:5432/persistent_memory
+      EMBEDDING_DIMENSION: 512
+      DB_ECHO: "false"
+    volumes:
+      - ./:/app
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ sqlalchemy==2.0.23
 pydantic==2.5.0
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
+alembic==1.14.1
+pgvector==0.3.6
+psycopg[binary]==3.2.6


### PR DESCRIPTION
# Postgres DB + SQLAlchemy ORM + Alembic Migrations
- Implemented Postgres representations of Users, People (who you have spoken to), and Episodes (conversations)
- Uses Docker Compose to manage DB hosting and backend

## Table Structure

### Person
- `id` - UUID primary key
- `user_id` - owner of this person record; links to `User`
- `name` - (`first_name`, `last_name`, `display_name`)
- `facts` - stored in `PersonFact`
- `dialogues` - linked through `Episodes`
- `face` - vector representation of facial features for recognition (`face_embedding`)
- `voice` - vector representation of vocal features for recognition (`voice_embedding`)
- `face_embedding_model` - model/version used to generate the face embedding
- `voice_embedding_model` - model/version used to generate the voice embedding
- `last_seen_at` - timestamp of the most recent known interaction
- `created_at` - timestamp when the person record was created
- `updated_at` - timestamp when the person record was last updated

### PersonFact
- `id` - UUID primary key
- `person_id` - links to `Person`
- `fact_text` - remembered fact about the person
- `source` - optional source label for where the fact came from
- `source_episode_id` - optional link to the `Episode` where the fact was learned
- `confidence` - optional confidence score for the fact
- `created_at` - timestamp when the fact was created
- `updated_at` - timestamp when the fact was last updated

### Episodes
- `id` - UUID primary key
- `start_time` - timestamp of conversation start
- `end_time` - timestamp of conversation end; nullable for in-progress conversations
- `dialogue_summary` - summary of conversation
- `summary_version` - optional version/model tag for the summary
- `importance_score` - optional score for ranking memorable conversations
- `user` - person wearing the glasses; links to `User`
- `person` - person talking to; links to `Person`
- `created_at` - timestamp when the episode record was created
- `updated_at` - timestamp when the episode record was last updated

### User
- `id` - UUID primary key
- `name` - (`first_name`, `last_name`, `display_name`)
- `username` - unique application username
- `oauth_provider` - optional OAuth provider name
- `oauth_subject` - optional OAuth subject/identifier from the provider
- `facts` - stored in `UserFact`
- `preferences` - JSON object of user settings/preferences
- `dialogues` - linked through `Episodes`
- `created_at` - timestamp when the user record was created
- `updated_at` - timestamp when the user record was last updated

### UserFact
- `id` - UUID primary key
- `user_id` - links to `User`
- `fact_text` - remembered fact about the user
- `source` - optional source label for where the fact came from
- `confidence` - optional confidence score for the fact
- `created_at` - timestamp when the fact was created
- `updated_at` - timestamp when the fact was last updated
