### PR TITLE
feat(resolver): rewrite person resolver per issue #8 flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,4 @@ Thumbs.db
 
 # Project-local docs/agent metadata
 AGENTS.md
-ISSUES.md
 egomem paper.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ Thumbs.db
 
 # Project-local docs/agent metadata
 AGENTS.md
+ISSUES.md
 egomem paper.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,6 @@ Thumbs.db
 
 # Project-local docs/agent metadata
 AGENTS.md
+CLAUDE.md
+.claude/
 egomem paper.pdf

--- a/backend/app/crud/memory_store.py
+++ b/backend/app/crud/memory_store.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import datetime, timezone
 import logging
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import create_engine, delete, func, or_, select
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, aliased, selectinload, sessionmaker
+from sqlalchemy.orm import Session, aliased, sessionmaker
 
 from ..core.config import get_settings
 from ..core.database import Base
 from ..models.episode import Episode
-from ..models.memory import Alias, Edge, EpisodeParticipant, Pref, Summary
+from ..models.memory import Edge, EpisodeParticipant, Summary
 from ..models.person import Person, PersonFact
 from ..models.user import User, UserFact
 from ..schema.memory import (
@@ -25,14 +25,16 @@ from ..schema.memory import (
     FactOut,
     PersonIn,
     PersonOut,
-    PrefIn,
-    PrefOut,
     ProfileContext,
     SummaryIn,
     SummaryOut,
 )
 
 logger = logging.getLogger("app.crud.memory_store")
+settings = get_settings()
+
+# Priority order for fact categories used in disambiguation
+FACT_CATEGORY_PRIORITY = ("visual_descriptor", "affiliation", "hobby")
 
 
 def _iso(dt: Optional[datetime]) -> Optional[str]:
@@ -66,26 +68,26 @@ def _split_name(name: str) -> tuple[str, str, str]:
 class MemoryStore:
     """Typed, deterministic memory access layer over the project schema."""
 
-    def __init__(self, db_url: str | None = None, owner_user_id: UUID | None = None) -> None:
-        """Create a store bound to an optional database URL and owner user.
+    def __init__(self, db_url: str | None = None, *, owner_user_id: UUID) -> None:
+        """Create a store bound to a database URL and owner user.
 
         Args:
             db_url: Override for the configured database URL.
-            owner_user_id: Existing user UUID that owns all memory records created
-                through this store. When omitted, the store will reuse the first
-                available user or create a default owner on first write.
+            owner_user_id: UUID of the user that owns all memory records
+                created and queried through this store.  The caller is
+                responsible for ensuring this user exists in the database.
         """
 
-        self._db_url = db_url or get_settings().database_url
+        self._db_url = db_url or settings.database_url
         self._owner_user_id = owner_user_id
-        # Track whether the owner UUID was explicitly supplied by the caller.
-        # When True, a missing owner is always a programming error and raises.
-        # When False, a stale cache (e.g. from a rolled-back read-only session)
-        # should silently recover by re-discovering or re-creating the owner.
-        self._explicit_owner: bool = owner_user_id is not None
         self._engine: Optional[Engine] = None
         self._Session: Optional[sessionmaker[Session]] = None
-        logger.info("MemoryStore created (db_url=%s)", self._db_url)
+        logger.info("MemoryStore created (db_url=%s, owner=%s)", self._db_url, owner_user_id)
+
+    @property
+    def owner_user_id(self) -> UUID:
+        """The UUID of the owner user scoping all operations."""
+        return self._owner_user_id
 
     def initialize(self, create_schema: bool = True) -> None:
         """Initialize the SQLAlchemy engine and create tables when requested."""
@@ -118,10 +120,11 @@ class MemoryStore:
             raise RuntimeError("MemoryStore not initialized - call .initialize() first")
         return self._Session
 
+    # ── Person CRUD ──────────────────────────────────────────
+
     def upsert_person(
         self,
         name: str,
-        aliases: list[str],
         face_key: Optional[str] = None,
         voice_key: Optional[str] = None,
         persona90: Optional[list[float]] = None,
@@ -130,8 +133,7 @@ class MemoryStore:
 
         The lookup is case-insensitive on the person's display name within the
         active owner scope. When a matching person already exists, the supplied
-        keys and persona vector are updated and the alias collection is replaced
-        with the provided set.
+        keys and persona vector are updated.
 
         Returns:
             The normalized stored person record.
@@ -139,7 +141,6 @@ class MemoryStore:
 
         data = PersonIn(
             name=name,
-            aliases=aliases,
             face_key=face_key,
             voice_key=voice_key,
             persona90=persona90 or [],
@@ -147,85 +148,68 @@ class MemoryStore:
         persona_supplied = persona90 is not None
 
         with self.Session() as session:
-            try:
-                with session.begin():
-                    owner = self._get_or_create_owner(session)
-                    person = session.scalar(
-                        select(Person).where(
-                            Person.user_id == owner.id,
-                            func.lower(func.coalesce(Person.display_name, "")) == data.name.lower(),
-                        )
+            with session.begin():
+                person = session.scalar(
+                    select(Person).where(
+                        Person.user_id == self._owner_user_id,
+                        func.lower(func.coalesce(Person.display_name, "")) == data.name.lower(),
                     )
+                )
 
-                    if person is None:
-                        first_name, last_name, display_name = _split_name(data.name)
-                        person = Person(
-                            user_id=owner.id,
-                            first_name=first_name,
-                            last_name=last_name,
-                            display_name=display_name,
-                            face_key=data.face_key,
-                            voice_key=data.voice_key,
-                            persona90=data.persona90,
-                        )
-                        session.add(person)
-                        session.flush()
-                        logger.debug("Inserted person id=%s name=%s", person.id, data.name)
-                    else:
-                        if data.face_key is not None:
-                            person.face_key = data.face_key
-                        if data.voice_key is not None:
-                            person.voice_key = data.voice_key
-                        if persona_supplied:
-                            person.persona90 = data.persona90
-                        first_name, last_name, display_name = _split_name(data.name)
-                        person.first_name = first_name
-                        person.last_name = last_name
-                        person.display_name = display_name
-                        person.updated_at = datetime.now(timezone.utc)
-                        session.flush()
-                        logger.debug("Updated person id=%s name=%s", person.id, data.name)
+                if person is None:
+                    first_name, last_name, display_name = _split_name(data.name)
+                    person = Person(
+                        user_id=self._owner_user_id,
+                        first_name=first_name,
+                        last_name=last_name,
+                        display_name=display_name,
+                        face_key=data.face_key,
+                        voice_key=data.voice_key,
+                        persona90=data.persona90,
+                    )
+                    session.add(person)
+                    session.flush()
+                    logger.debug("Inserted person id=%s name=%s", person.id, data.name)
+                else:
+                    if data.face_key is not None:
+                        person.face_key = data.face_key
+                    if data.voice_key is not None:
+                        person.voice_key = data.voice_key
+                    if persona_supplied:
+                        person.persona90 = data.persona90
+                    first_name, last_name, display_name = _split_name(data.name)
+                    person.first_name = first_name
+                    person.last_name = last_name
+                    person.display_name = display_name
+                    person.updated_at = datetime.now(timezone.utc)
+                    session.flush()
+                    logger.debug("Updated person id=%s name=%s", person.id, data.name)
 
-                    session.execute(delete(Alias).where(Alias.person_id == person.id))
-                    for alias in data.aliases:
-                        session.add(Alias(person_id=person.id, alias=alias))
-
-                return self._load_person(session, person.id)
-            except IntegrityError as exc:
-                raise ValueError(f"Unable to upsert person '{name}': {exc.orig}") from exc
+            return self._load_person(session, person.id)
 
     def list_people(self) -> list[Person]:
-        """Return all people for the current owner with aliases eagerly loaded.
-
-        This is a read-only method intended for resolution and search use cases
-        where the caller needs access to ``display_name``, ``first_name``, and
-        ``aliases`` on each person.  Unlike write methods, this will never
-        create a default owner; it returns an empty list when no owner exists.
+        """Return all people for the current owner.
 
         Returns:
-            Person ORM instances with their ``aliases`` relationship populated.
-            An empty list when no owner or people exist.
+            Person ORM instances.
+            An empty list when no people exist for the owner.
         """
 
         with self.Session() as session:
-            owner_id = self._find_owner_id(session)
-            if owner_id is None:
-                return []
             people = list(
                 session.scalars(
-                    select(Person)
-                    .options(selectinload(Person.aliases))
-                    .where(Person.user_id == owner_id)
+                    select(Person).where(Person.user_id == self._owner_user_id)
                 ).all()
             )
-            logger.debug("list_people: %d people for owner=%s", len(people), owner_id)
+            logger.debug("list_people: %d people for owner=%s", len(people), self._owner_user_id)
             return people
 
-    def resolve_person_by_name_or_alias(self, text: str) -> Optional[PersonOut]:
-        """Resolve a person by display name or alias for the current owner.
+    def resolve_person_by_name(self, text: str) -> Optional[PersonOut]:
+        """Resolve a person by display name for the current owner.
 
-        The match is case-insensitive and restricted to people owned by the
-        store's active user. Blank input returns ``None`` instead of raising.
+        Case-insensitive match on display_name. Used by the ingestion pipeline
+        for exact-name lookups. For query-based resolution with ambiguity
+        handling, use PersonResolver instead.
 
         Returns:
             The matching person record, or ``None`` when no match exists.
@@ -236,18 +220,11 @@ class MemoryStore:
             return None
 
         with self.Session() as session:
-            owner = self._get_or_create_owner(session)
             person = session.scalar(
-                select(Person)
-                .outerjoin(Alias, Alias.person_id == Person.id)
-                .where(
-                    Person.user_id == owner.id,
-                    or_(
-                        func.lower(func.coalesce(Person.display_name, "")) == cleaned.lower(),
-                        func.lower(Alias.alias) == cleaned.lower(),
-                    )
+                select(Person).where(
+                    Person.user_id == self._owner_user_id,
+                    func.lower(func.coalesce(Person.display_name, "")) == cleaned.lower(),
                 )
-                .limit(1)
             )
 
             if person is None:
@@ -256,6 +233,8 @@ class MemoryStore:
 
             logger.debug("resolve_person: '%s' -> id=%s", cleaned, person.id)
             return self._load_person(session, person.id)
+
+    # ── Episode / Fact / Summary / Edge writes ───────────────
 
     def write_episode(
         self,
@@ -266,10 +245,6 @@ class MemoryStore:
         participants: Optional[list[UUID]] = None,
     ) -> UUID:
         """Insert a conversation episode and its participant links.
-
-        The first participant becomes the primary ``Episode.person_id`` so the
-        episode remains compatible with the main schema, while every supplied
-        participant is also written to ``EpisodeParticipant``.
 
         Returns:
             The UUID of the created episode row.
@@ -285,14 +260,13 @@ class MemoryStore:
 
         with self.Session() as session:
             with session.begin():
-                owner = self._get_or_create_owner(session)
                 ordered_participants = list(dict.fromkeys(data.participant_ids))
                 if not ordered_participants:
                     raise ValueError("write_episode requires at least one participant")
-                self._assert_people_exist(session, ordered_participants, owner.id)
+                self._assert_people_exist(session, ordered_participants, self._owner_user_id)
 
                 episode = Episode(
-                    user_id=owner.id,
+                    user_id=self._owner_user_id,
                     person_id=ordered_participants[0],
                     start_time=data.time_start,
                     end_time=data.time_end,
@@ -307,13 +281,7 @@ class MemoryStore:
 
                 episode_id = episode.id
 
-            logger.debug(
-                "Wrote episode id=%s (%s -> %s, %d participants)",
-                episode_id,
-                data.time_start.isoformat(),
-                data.time_end.isoformat(),
-                len(ordered_participants),
-            )
+            logger.debug("Wrote episode id=%s", episode_id)
             return episode_id
 
     def write_fact(
@@ -327,9 +295,6 @@ class MemoryStore:
         valid_to: Optional[datetime] = None,
     ) -> UUID:
         """Persist a structured fact about a person.
-
-        The person must belong to the current owner. When ``episode_id`` is
-        provided, the fact is linked back to the episode where it was learned.
 
         Returns:
             The UUID of the created fact row.
@@ -347,9 +312,8 @@ class MemoryStore:
 
         with self.Session() as session:
             with session.begin():
-                owner = self._get_or_create_owner(session)
-                self._assert_person_exists(session, data.person_id, owner.id)
-                self._assert_episode_exists(session, data.episode_id, owner.id)
+                self._assert_person_exists(session, data.person_id, self._owner_user_id)
+                self._assert_episode_exists(session, data.episode_id, self._owner_user_id)
 
                 row = PersonFact(
                     person_id=data.person_id,
@@ -367,48 +331,6 @@ class MemoryStore:
             logger.debug("Wrote fact id=%s for person=%s", fact_id, data.person_id)
             return fact_id
 
-    def write_pref(
-        self,
-        person_id: UUID,
-        pref_text: str,
-        confidence: float = 1.0,
-        episode_id: Optional[UUID] = None,
-    ) -> UUID:
-        """Persist a preference remembered about a person.
-
-        Preferences are owner-scoped through the referenced person and may be
-        associated with an originating episode.
-
-        Returns:
-            The UUID of the created preference row.
-        """
-
-        data = PrefIn(
-            person_id=person_id,
-            pref_text=pref_text,
-            confidence=confidence,
-            episode_id=episode_id,
-        )
-
-        with self.Session() as session:
-            with session.begin():
-                owner = self._get_or_create_owner(session)
-                self._assert_person_exists(session, data.person_id, owner.id)
-                self._assert_episode_exists(session, data.episode_id, owner.id)
-
-                row = Pref(
-                    person_id=data.person_id,
-                    pref_text=data.pref_text,
-                    confidence=_decimal(data.confidence),
-                    episode_id=data.episode_id,
-                )
-                session.add(row)
-                session.flush()
-                pref_id = row.id
-
-            logger.debug("Wrote pref id=%s for person=%s", pref_id, data.person_id)
-            return pref_id
-
     def write_summary(
         self,
         person_id: UUID,
@@ -418,9 +340,6 @@ class MemoryStore:
         episode_id: Optional[UUID] = None,
     ) -> UUID:
         """Persist a summary slice for a person.
-
-        This stores the human-readable summary text plus optional time bounds
-        describing the source interaction window and an optional backing episode.
 
         Returns:
             The UUID of the created summary row.
@@ -436,9 +355,8 @@ class MemoryStore:
 
         with self.Session() as session:
             with session.begin():
-                owner = self._get_or_create_owner(session)
-                self._assert_person_exists(session, data.person_id, owner.id)
-                self._assert_episode_exists(session, data.episode_id, owner.id)
+                self._assert_person_exists(session, data.person_id, self._owner_user_id)
+                self._assert_episode_exists(session, data.episode_id, self._owner_user_id)
 
                 row = Summary(
                     person_id=data.person_id,
@@ -464,9 +382,7 @@ class MemoryStore:
     ) -> UUID:
         """Create or update a directed relationship between two people.
 
-        Edges are unique by ``(src_id, relation, dst_id)``. Rewriting an
-        existing edge updates its confidence and optional episode reference
-        instead of creating a duplicate row.
+        Edges are unique by ``(src_id, relation, dst_id)``.
 
         Returns:
             The UUID of the inserted or updated edge row.
@@ -482,10 +398,9 @@ class MemoryStore:
 
         with self.Session() as session:
             with session.begin():
-                owner = self._get_or_create_owner(session)
-                self._assert_person_exists(session, data.src_id, owner.id)
-                self._assert_person_exists(session, data.dst_id, owner.id)
-                self._assert_episode_exists(session, data.episode_id, owner.id)
+                self._assert_person_exists(session, data.src_id, self._owner_user_id)
+                self._assert_person_exists(session, data.dst_id, self._owner_user_id)
+                self._assert_episode_exists(session, data.episode_id, self._owner_user_id)
 
                 edge = session.scalar(
                     select(Edge).where(
@@ -512,54 +427,71 @@ class MemoryStore:
 
                 edge_id = edge.id
 
-            logger.debug(
-                "Wrote edge id=%s: person %s -[%s]-> person %s",
-                edge_id,
-                data.src_id,
-                data.relation,
-                data.dst_id,
-            )
+            logger.debug("Wrote edge id=%s: %s -[%s]-> %s", edge_id, data.src_id, data.relation, data.dst_id)
             return edge_id
+
+    # ── Read methods ─────────────────────────────────────────
 
     def get_user_facts(self) -> list[str]:
         """Return all fact texts stored for the current owner user.
 
-        Used by the ingestion pipeline to provide wearer context when detecting
-        shared interests between the wearer and an interlocutor.
+        Used by the ingestion pipeline to provide wearer context.
         """
 
         with self.Session() as session:
-            owner = self._get_or_create_owner(session)
             rows = session.scalars(
                 select(UserFact.fact_text)
-                .where(UserFact.user_id == owner.id)
+                .where(UserFact.user_id == self._owner_user_id)
                 .order_by(UserFact.created_at.asc())
             ).all()
             return list(rows)
 
-    def get_profile_context(self, person_id: UUID) -> ProfileContext:
-        """Return the issue-specified profile context bundle for one person.
+    def get_disambiguation_hints(self, person_id: UUID) -> dict[str, list[str]]:
+        """Return categorized fact texts for person disambiguation.
 
-        The returned structure contains facts, preferences, summaries, outgoing
-        edges, and the stored ``persona90`` vector ordered newest-first within
-        each collection.
+        Groups facts by ``fact_category`` in priority order:
+        visual_descriptor, affiliation, hobby.
+
+        Returns:
+            Dict keyed by category with lists of fact_text strings.
+            Categories with no facts are omitted.
+        """
+
+        with self.Session() as session:
+            rows = session.execute(
+                select(PersonFact.fact_category, PersonFact.fact_text)
+                .where(
+                    PersonFact.person_id == person_id,
+                    PersonFact.fact_category.isnot(None),
+                )
+                .order_by(PersonFact.created_at.desc())
+            ).all()
+
+            hints: dict[str, list[str]] = {}
+            for category in FACT_CATEGORY_PRIORITY:
+                texts = [text for cat, text in rows if cat == category]
+                if texts:
+                    hints[category] = texts
+
+            return hints
+
+    def get_profile_context(self, person_id: UUID) -> ProfileContext:
+        """Return the profile context bundle for one person.
+
+        The returned structure contains facts, summaries, outgoing edges,
+        and the stored ``persona90`` vector ordered newest-first.
 
         Returns:
             A ``ProfileContext`` ready for deterministic retrieval use.
         """
 
         with self.Session() as session:
-            owner = self._get_or_create_owner(session)
-            person = self._get_person(session, person_id, owner.id)
+            person = self._get_person(session, person_id, self._owner_user_id)
 
             facts_rows = session.scalars(
                 select(PersonFact)
                 .where(PersonFact.person_id == person_id)
                 .order_by(PersonFact.created_at.desc())
-            ).all()
-
-            prefs_rows = session.scalars(
-                select(Pref).where(Pref.person_id == person_id).order_by(Pref.created_at.desc())
             ).all()
 
             summaries_rows = session.scalars(
@@ -590,17 +522,6 @@ class MemoryStore:
                 for row in facts_rows
             ]
 
-            prefs = [
-                PrefOut(
-                    id=row.id,
-                    pref_text=row.pref_text,
-                    confidence=_float(row.confidence),
-                    episode_id=row.episode_id,
-                    created_at=_iso(row.created_at) or "",
-                )
-                for row in prefs_rows
-            ]
-
             summaries = [
                 SummaryOut(
                     id=row.id,
@@ -626,28 +547,17 @@ class MemoryStore:
                 for edge, dst_name in edge_rows
             ]
 
-            logger.debug(
-                "Profile context for person=%s: %d facts, %d prefs, %d summaries, %d edges",
-                person_id,
-                len(facts),
-                len(prefs),
-                len(summaries),
-                len(edges),
-            )
-
             return ProfileContext(
                 facts=facts,
-                prefs=prefs,
                 summaries=summaries,
                 edges_from=edges,
                 persona90=person.persona90 or [],
             )
 
+    # ── Private helpers ──────────────────────────────────────
+
     def _load_person(self, session: Session, person_id: UUID) -> PersonOut:
         person = self._get_person(session, person_id, person_user_id=None)
-        aliases = session.scalars(
-            select(Alias.alias).where(Alias.person_id == person_id).order_by(Alias.alias.asc())
-        ).all()
 
         return PersonOut(
             id=person.id,
@@ -655,64 +565,9 @@ class MemoryStore:
             face_key=person.face_key,
             voice_key=person.voice_key,
             persona90=person.persona90 or [],
-            aliases=list(aliases),
             created_at=_iso(person.created_at) or "",
             updated_at=_iso(person.updated_at) or "",
         )
-
-    def _find_owner_id(self, session: Session) -> UUID | None:
-        """Return the active owner's UUID without creating a default user.
-
-        This is the read-safe counterpart to ``_get_or_create_owner``.  When
-        the cached ``_owner_user_id`` points to a deleted or rolled-back user,
-        the stale reference is cleared and the lookup falls through to the
-        first available user.  Returns ``None`` when no user exists at all.
-        """
-
-        if self._owner_user_id is not None:
-            if session.get(User, self._owner_user_id) is not None:
-                return self._owner_user_id
-            # Stale reference -- clear and fall through
-            self._owner_user_id = None
-
-        owner = session.scalar(
-            select(User).order_by(User.created_at.asc()).limit(1)
-        )
-        if owner is not None:
-            self._owner_user_id = owner.id
-            return owner.id
-        return None
-
-    def _get_or_create_owner(self, session: Session) -> User:
-        if self._owner_user_id is not None:
-            owner = session.get(User, self._owner_user_id)
-            if owner is not None:
-                return owner
-            if self._explicit_owner:
-                # Caller supplied a specific UUID — a missing row is always an error.
-                raise ValueError(f"Owner user id={self._owner_user_id} not found")
-            # Auto-cached UUID is stale (e.g. from a rolled-back read-only session).
-            # Clear the cache and fall through to re-discover / re-create below.
-            logger.debug(
-                "_get_or_create_owner: stale cached id=%s, re-discovering owner",
-                self._owner_user_id,
-            )
-            self._owner_user_id = None
-
-        owner = session.scalar(select(User).order_by(User.created_at.asc()).limit(1))
-        if owner is None:
-            owner = User(
-                first_name="Memory",
-                last_name="Owner",
-                display_name="Memory Store Owner",
-                username="memory-store-owner",
-            )
-            session.add(owner)
-            session.flush()
-            logger.debug("Created default owner user id=%s", owner.id)
-
-        self._owner_user_id = owner.id
-        return owner
 
     def _get_person(self, session: Session, person_id: UUID, person_user_id: UUID | None) -> Person:
         person = session.get(Person, person_id)

--- a/backend/app/crud/memory_store.py
+++ b/backend/app/crud/memory_store.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from sqlalchemy import create_engine, delete, func, or_, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, aliased, sessionmaker
+from sqlalchemy.orm import Session, aliased, selectinload, sessionmaker
 
 from ..core.config import get_settings
 from ..core.database import Base
@@ -193,6 +193,33 @@ class MemoryStore:
                 return self._load_person(session, person.id)
             except IntegrityError as exc:
                 raise ValueError(f"Unable to upsert person '{name}': {exc.orig}") from exc
+
+    def list_people(self) -> list[Person]:
+        """Return all people for the current owner with aliases eagerly loaded.
+
+        This is a read-only method intended for resolution and search use cases
+        where the caller needs access to ``display_name``, ``first_name``, and
+        ``aliases`` on each person.  Unlike write methods, this will never
+        create a default owner; it returns an empty list when no owner exists.
+
+        Returns:
+            Person ORM instances with their ``aliases`` relationship populated.
+            An empty list when no owner or people exist.
+        """
+
+        with self.Session() as session:
+            owner_id = self._find_owner_id(session)
+            if owner_id is None:
+                return []
+            people = list(
+                session.scalars(
+                    select(Person)
+                    .options(selectinload(Person.aliases))
+                    .where(Person.user_id == owner_id)
+                ).all()
+            )
+            logger.debug("list_people: %d people for owner=%s", len(people), owner_id)
+            return people
 
     def resolve_person_by_name_or_alias(self, text: str) -> Optional[PersonOut]:
         """Resolve a person by display name or alias for the current owner.
@@ -632,6 +659,29 @@ class MemoryStore:
             created_at=_iso(person.created_at) or "",
             updated_at=_iso(person.updated_at) or "",
         )
+
+    def _find_owner_id(self, session: Session) -> UUID | None:
+        """Return the active owner's UUID without creating a default user.
+
+        This is the read-safe counterpart to ``_get_or_create_owner``.  When
+        the cached ``_owner_user_id`` points to a deleted or rolled-back user,
+        the stale reference is cleared and the lookup falls through to the
+        first available user.  Returns ``None`` when no user exists at all.
+        """
+
+        if self._owner_user_id is not None:
+            if session.get(User, self._owner_user_id) is not None:
+                return self._owner_user_id
+            # Stale reference -- clear and fall through
+            self._owner_user_id = None
+
+        owner = session.scalar(
+            select(User).order_by(User.created_at.asc()).limit(1)
+        )
+        if owner is not None:
+            self._owner_user_id = owner.id
+            return owner.id
+        return None
 
     def _get_or_create_owner(self, session: Session) -> User:
         if self._owner_user_id is not None:

--- a/backend/app/crud/person_resolver.py
+++ b/backend/app/crud/person_resolver.py
@@ -4,30 +4,8 @@ import re
 from uuid import UUID
 
 from .memory_store import MemoryStore
+from ..models.person import Person
 from ..schema.person_resolver import ResolveCandidate, ResolveResult
-
-ACTIVE_INTERLOCUTOR_PHRASES = {
-    "this person",
-    "the person i was talking to",
-    "the person i'm speaking with",
-    "the person i am speaking with",
-}
-
-PRONOUN_PATTERNS = {
-    "they",
-    "them",
-    "him",
-    "her",
-}
-
-# Confidence tiers for resolution results
-ACTIVE_INTERLOCUTOR_CONFIDENCE = 0.95
-EXACT_MATCH_CONFIDENCE = 0.95
-SENTENCE_NAME_CONFIDENCE = 0.8
-SENTENCE_ALIAS_CONFIDENCE = 0.7
-FIRST_NAME_CONFIDENCE = 0.6
-AMBIGUOUS_CONFIDENCE = 0.4
-NO_MATCH_CONFIDENCE = 0.0
 
 WHITESPACE_RE = re.compile(r"\s+")
 WORD_RE = re.compile(r"[a-z0-9']+")
@@ -48,48 +26,101 @@ def _contains_phrase(text: str, phrase: str) -> bool:
     return re.search(pattern, normalized_text) is not None
 
 
-def _is_active_interlocutor_reference(text: str) -> bool:
-    """Detect relative references that should use active interlocutor state."""
+def _person_name(person: Person) -> str:
+    """Return the best available display name for a person."""
 
-    return any(
-        _contains_phrase(text, phrase)
-        for phrase in ACTIVE_INTERLOCUTOR_PHRASES | PRONOUN_PATTERNS
-    )
+    return person.display_name or f"{person.first_name} {person.last_name}".strip()
 
 
-def _resolved(person_id: UUID, confidence: float) -> ResolveResult:
-    """Build a resolved, non-ambiguous match result."""
+class PersonResolver:
+    """Resolve the subject of a user query to a known person.
 
-    return ResolveResult(
-        person_id=person_id,
-        confidence=confidence,
-        is_ambiguous=False,
-        candidates=[],
-    )
+    Given a query such as "what did Bob say last week", determines which
+    person in the memory store is being referenced. When multiple people
+    match, returns candidates with categorized fact hints for disambiguation
+    by a downstream model (GPT 5 nano).
+    """
 
+    def __init__(self, store: MemoryStore) -> None:
+        self.store = store
 
-def _candidate(person_id: UUID, name: str, confidence: float) -> ResolveCandidate:
-    """Build one ambiguity candidate entry."""
+    def resolve_person_from_query(self, query_text: str) -> ResolveResult:
+        """Determine which person a user query is referencing.
 
-    return ResolveCandidate(
-        person_id=person_id,
-        name=name,
-        confidence=confidence,
-    )
+        Resolution:
+        1. Display-name match (handles both exact and embedded in sentence)
+        2. First-name token fallback
 
+        At each step: 0 matches continues, 1 match resolves, 2+ returns
+        ambiguous candidates with fact hints for disambiguation.
 
-def _ambiguous(
-    candidates: list[ResolveCandidate],
-    confidence: float = AMBIGUOUS_CONFIDENCE,
-) -> ResolveResult:
-    """Build an ambiguous result with candidate options."""
+        Args:
+            query_text: Natural-language query containing a person name.
 
-    return ResolveResult(
-        person_id=None,
-        confidence=confidence,
-        is_ambiguous=True,
-        candidates=candidates,
-    )
+        Returns:
+            ResolveResult with person_id when a unique match is found,
+            or is_ambiguous=True with candidates when multiple match.
+        """
+
+        cleaned = _normalize(query_text)
+        if not cleaned:
+            return _no_match()
+
+        people = self.store.list_people()
+        if not people:
+            return _no_match()
+
+        # Pass 1: display-name match
+        name_matches = [p for p in people if _contains_phrase(cleaned, _person_name(p))]
+        result = self._branch(name_matches)
+        if result is not None:
+            return result
+
+        # Pass 2: first-name token fallback
+        tokens = set(WORD_RE.findall(cleaned))
+        first_matches = [
+            p for p in people
+            if _normalize(p.first_name) in tokens
+        ]
+        result = self._branch(first_matches)
+        if result is not None:
+            return result
+
+        return _no_match()
+
+    def _branch(self, matches: list[Person]) -> ResolveResult | None:
+        """Apply the 0/1/N branching logic for a set of matches."""
+
+        if not matches:
+            return None
+
+        # Deduplicate (same person matched via different paths)
+        seen: dict[UUID, Person] = {}
+        for p in matches:
+            if p.id not in seen:
+                seen[p.id] = p
+        unique = list(seen.values())
+
+        if len(unique) == 1:
+            return ResolveResult(
+                person_id=unique[0].id,
+                is_ambiguous=False,
+                candidates=[],
+            )
+
+        candidates = [
+            ResolveCandidate(
+                person_id=p.id,
+                name=_person_name(p),
+                hints=self.store.get_disambiguation_hints(p.id),
+            )
+            for p in sorted(unique, key=lambda p: _person_name(p).lower())
+        ]
+        return ResolveResult(
+            person_id=None,
+            is_ambiguous=True,
+            candidates=candidates,
+        )
 
 
 def _no_match() -> ResolveResult:
@@ -97,137 +128,9 @@ def _no_match() -> ResolveResult:
 
     return ResolveResult(
         person_id=None,
-        confidence=NO_MATCH_CONFIDENCE,
         is_ambiguous=False,
         candidates=[],
     )
-
-
-class PersonResolver:
-    """Resolve a referenced person from a user query."""
-
-    def __init__(self, store: MemoryStore) -> None:
-        self.store = store
-        self._active_interlocutor_id: UUID | None = None
-
-    def set_active_interlocutor(self, person_id: UUID | None) -> None:
-        self._active_interlocutor_id = person_id
-
-    def _match_name_or_alias_in_sentence(self, query_text: str) -> ResolveResult | None:
-        """Resolve a full display name or alias mentioned inside longer text."""
-
-        matches: dict[UUID, tuple[str, float]] = {}
-
-        for person in self.store.list_people():
-            display_name = person.display_name or person.first_name
-            if display_name and _contains_phrase(query_text, display_name):
-                matches[person.id] = (display_name, SENTENCE_NAME_CONFIDENCE)
-
-            for alias in person.aliases:
-                if _contains_phrase(query_text, alias.alias):
-                    current = matches.get(person.id)
-                    alias_confidence = SENTENCE_ALIAS_CONFIDENCE
-                    if current is None or alias_confidence > current[1]:
-                        matches[person.id] = (display_name, alias_confidence)
-
-        if not matches:
-            return None
-
-        if len(matches) == 1:
-            person_id, (_, confidence) = next(iter(matches.items()))
-            return _resolved(person_id, confidence)
-
-        candidates = [
-            _candidate(person_id, name, confidence)
-            for person_id, (name, confidence) in sorted(
-                matches.items(),
-                key=lambda item: (-item[1][1], item[1][0].lower()),
-            )
-        ]
-        return _ambiguous(candidates)
-
-    def _match_first_name(self, query_text: str) -> ResolveResult | None:
-        """Resolve or disambiguate first-name references in the query text."""
-
-        tokens = set(WORD_RE.findall(_normalize(query_text)))
-        if not tokens:
-            return None
-
-        matches: list[tuple[UUID, str]] = []
-
-        for person in self.store.list_people():
-            first_name = _normalize(person.first_name)
-            if first_name and first_name in tokens:
-                matches.append((person.id, person.display_name or person.first_name))
-
-        if not matches:
-            return None
-
-        unique_matches = list(dict.fromkeys(matches))
-        if len(unique_matches) == 1:
-            person_id, _ = unique_matches[0]
-            return _resolved(person_id, FIRST_NAME_CONFIDENCE)
-
-        candidates = [
-            _candidate(person_id, name, AMBIGUOUS_CONFIDENCE)
-            for person_id, name in sorted(unique_matches, key=lambda item: item[1].lower())
-        ]
-        return _ambiguous(candidates, confidence=AMBIGUOUS_CONFIDENCE)
-
-    def resolve_person_from_query(self, query_text: str) -> ResolveResult:
-        """Determine which person a user query is referencing.
-
-        Resolution happens in the following priority order:
-
-        1. Exact display-name and alias matches (case-insensitive)
-        2. Embedded full-name and alias mentions inside longer text
-        3. First-name token matches (ambiguous if multiple people share a name)
-        4. Active interlocutor phrases / pronoun references
-
-        Name-based matching is attempted before pronoun or relative-reference
-        resolution so that queries like ``"What did Emily tell him?"`` resolve
-        to Emily rather than the active interlocutor.
-
-        This function resolves identity only and does not retrieve profile data.
-
-        Args:
-            query_text: Natural-language query that may contain a person
-                reference by name, alias, or relative pronoun.
-
-        Returns:
-            ResolveResult with person_id and confidence when a unique
-            match is found, or is_ambiguous=True with candidates when
-            multiple people match.
-        """
-
-        cleaned = _normalize(query_text)
-        if not cleaned:
-            return _no_match()
-
-        # 1. Exact display-name / alias
-        exact = self.store.resolve_person_by_name_or_alias(cleaned)
-        if exact is not None:
-            return _resolved(exact.id, confidence=EXACT_MATCH_CONFIDENCE)
-
-        # 2. Name or alias embedded in a longer sentence
-        sentence_match = self._match_name_or_alias_in_sentence(cleaned)
-        if sentence_match is not None:
-            return sentence_match
-
-        # 3. First-name token match
-        first_name_match = self._match_first_name(cleaned)
-        if first_name_match is not None:
-            return first_name_match
-
-        # 4. Relative / pronoun reference to the active interlocutor
-        if _is_active_interlocutor_reference(cleaned):
-            if self._active_interlocutor_id is not None:
-                return _resolved(
-                    self._active_interlocutor_id,
-                    confidence=ACTIVE_INTERLOCUTOR_CONFIDENCE,
-                )
-
-        return _no_match()
 
 
 __all__ = ["PersonResolver"]

--- a/backend/app/crud/person_resolver.py
+++ b/backend/app/crud/person_resolver.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import re
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from .memory_store import MemoryStore
+from ..models.person import Person
+from ..models.user import User
+from ..schema.person_resolver import ResolveCandidate, ResolveResult
+
+ACTIVE_INTERLOCUTOR_PHRASES = {
+    "this person",
+    "the person i was talking to",
+    "the person i'm speaking with",
+    "the person i am speaking with",
+}
+
+PRONOUN_PATTERNS = {
+    "they",
+    "them",
+    "him",
+    "her",
+}
+
+ACTIVE_INTERLOCUTOR_CONFIDENCE = 0.95
+EXACT_MATCH_CONFIDENCE = 0.95
+SENTENCE_NAME_CONFIDENCE = 0.8
+SENTENCE_ALIAS_CONFIDENCE = 0.7
+FIRST_NAME_CONFIDENCE = 0.6
+AMBIGUOUS_CONFIDENCE = 0.4
+NO_MATCH_CONFIDENCE = 0.0
+
+WHITESPACE_RE = re.compile(r"\s+")
+WORD_RE = re.compile(r"[a-z0-9']+")
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, trim, and collapse internal whitespace."""
+
+    return WHITESPACE_RE.sub(" ", text.strip().lower())
+
+
+def _contains_phrase(text: str, phrase: str) -> bool:
+    """Return True when a phrase appears with word boundaries."""
+
+    normalized_text = _normalize(text)
+    normalized_phrase = _normalize(phrase)
+    pattern = rf"(?<!\w){re.escape(normalized_phrase)}(?!\w)"
+    return re.search(pattern, normalized_text) is not None
+
+
+def _is_active_interlocutor_reference(text: str) -> bool:
+    """Detect relative references that should use active interlocutor state."""
+
+    return any(
+        _contains_phrase(text, phrase)
+        for phrase in ACTIVE_INTERLOCUTOR_PHRASES | PRONOUN_PATTERNS
+    )
+
+
+def _resolved(person_id: UUID, confidence: float) -> ResolveResult:
+    """Build a resolved, non-ambiguous match result."""
+
+    return ResolveResult(
+        person_id=person_id,
+        confidence=confidence,
+        is_ambiguous=False,
+        candidates=[],
+    )
+
+
+def _candidate(person_id: UUID, name: str, confidence: float) -> ResolveCandidate:
+    """Build one ambiguity candidate entry."""
+
+    return ResolveCandidate(
+        person_id=person_id,
+        name=name,
+        confidence=confidence,
+    )
+
+
+def _ambiguous(
+    candidates: list[ResolveCandidate],
+    confidence: float = AMBIGUOUS_CONFIDENCE,
+) -> ResolveResult:
+    """Build an ambiguous result with candidate options."""
+
+    return ResolveResult(
+        person_id=None,
+        confidence=confidence,
+        is_ambiguous=True,
+        candidates=candidates,
+    )
+
+
+def _no_match() -> ResolveResult:
+    """Build a no-match result."""
+
+    return ResolveResult(
+        person_id=None,
+        confidence=NO_MATCH_CONFIDENCE,
+        is_ambiguous=False,
+        candidates=[],
+    )
+
+
+class PersonResolver:
+    """Resolve a referenced person from a user query."""
+
+    def __init__(self, store: MemoryStore) -> None:
+        self.store = store
+        self._active_interlocutor_id: UUID | None = None
+
+    def set_active_interlocutor(self, person_id: UUID | None) -> None:
+        self._active_interlocutor_id = person_id
+
+    def _list_people(self) -> list[Person]:
+        """Return people for the current owner without creating a new owner on reads."""
+
+        with self.store.Session() as session:
+            owner_id = self.store._owner_user_id
+            if owner_id is not None:
+                owner = session.get(User, owner_id)
+                if owner is None:
+                    self.store._owner_user_id = None
+                    return []
+            else:
+                owner_id = session.scalar(select(User.id).order_by(User.created_at.asc()).limit(1))
+                if owner_id is None:
+                    return []
+                self.store._owner_user_id = owner_id
+
+            return list(
+                session.scalars(
+                    select(Person)
+                    .options(selectinload(Person.aliases))
+                    .where(Person.user_id == owner_id)
+                ).all()
+            )
+
+    def _match_name_or_alias_in_sentence(self, query_text: str) -> ResolveResult | None:
+        """Resolve a full display name or alias mentioned inside longer text."""
+
+        matches: dict[UUID, tuple[str, float]] = {}
+
+        for person in self._list_people():
+            display_name = person.display_name or person.first_name
+            if display_name and _contains_phrase(query_text, display_name):
+                matches[person.id] = (display_name, SENTENCE_NAME_CONFIDENCE)
+
+            for alias in person.aliases:
+                if _contains_phrase(query_text, alias.alias):
+                    current = matches.get(person.id)
+                    alias_confidence = SENTENCE_ALIAS_CONFIDENCE
+                    if current is None or alias_confidence > current[1]:
+                        matches[person.id] = (display_name, alias_confidence)
+
+        if not matches:
+            return None
+
+        if len(matches) == 1:
+            person_id, (_, confidence) = next(iter(matches.items()))
+            return _resolved(person_id, confidence)
+
+        candidates = [
+            _candidate(person_id, name, confidence)
+            for person_id, (name, confidence) in sorted(
+                matches.items(),
+                key=lambda item: (-item[1][1], item[1][0].lower()),
+            )
+        ]
+        return _ambiguous(candidates)
+
+    def _match_first_name(self, query_text: str) -> ResolveResult | None:
+        """Resolve or disambiguate first-name references in the query text."""
+
+        tokens = set(WORD_RE.findall(_normalize(query_text)))
+        if not tokens:
+            return None
+
+        matches: list[tuple[UUID, str]] = []
+
+        for person in self._list_people():
+            first_name = _normalize(person.first_name)
+            if first_name and first_name in tokens:
+                matches.append((person.id, person.display_name or person.first_name))
+
+        if not matches:
+            return None
+
+        unique_matches = list(dict.fromkeys(matches))
+        if len(unique_matches) == 1:
+            person_id, _ = unique_matches[0]
+            return _resolved(person_id, FIRST_NAME_CONFIDENCE)
+
+        candidates = [
+            _candidate(person_id, name, AMBIGUOUS_CONFIDENCE)
+            for person_id, name in sorted(unique_matches, key=lambda item: item[1].lower())
+        ]
+        return _ambiguous(candidates, confidence=AMBIGUOUS_CONFIDENCE)
+
+    def resolve_person_from_query(self, query_text: str) -> ResolveResult:
+        """
+        Determine which person a user query is referencing.
+        Resolution happens in the following order:
+        1. Active interlocutor phrases included in ACTIVE_INTERLOCUTOR_PHRASES and PRONOUN_PATTERNS
+        2. Exact display-name and alias matches (case-insensitive)
+        3. Embedded full-name and alias mentions inside longer text
+        4. First-name matches (ambiguous if multiple people have the same name)
+
+        This function resolves identity and does not retrieve profile data.
+
+        Args:
+            query_text: Natural-language query that may contain a person
+                reference by name, alias, or relative pronoun.
+
+        Returns:
+            ResolveResult with person_id and confidence when a unique
+            match is found, or is_ambiguous=True with candidates when
+            multiple people match.
+        """
+        cleaned = _normalize(query_text)
+        if not cleaned:
+            return _no_match()
+
+        if _is_active_interlocutor_reference(cleaned):
+            if self._active_interlocutor_id is not None:
+                return _resolved(
+                    self._active_interlocutor_id,
+                    confidence=ACTIVE_INTERLOCUTOR_CONFIDENCE,
+                )
+            return _no_match()
+
+        exact = self.store.resolve_person_by_name_or_alias(cleaned)
+        if exact is not None:
+            return _resolved(exact.id, confidence=EXACT_MATCH_CONFIDENCE)
+
+        sentence_match = self._match_name_or_alias_in_sentence(cleaned)
+        if sentence_match is not None:
+            return sentence_match
+
+        first_name_match = self._match_first_name(cleaned)
+        if first_name_match is not None:
+            return first_name_match
+
+        return _no_match()
+
+        

--- a/backend/app/crud/person_resolver.py
+++ b/backend/app/crud/person_resolver.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 import re
 from uuid import UUID
 
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
-
 from .memory_store import MemoryStore
-from ..models.person import Person
-from ..models.user import User
 from ..schema.person_resolver import ResolveCandidate, ResolveResult
 
 ACTIVE_INTERLOCUTOR_PHRASES = {
@@ -25,6 +20,7 @@ PRONOUN_PATTERNS = {
     "her",
 }
 
+# Confidence tiers for resolution results
 ACTIVE_INTERLOCUTOR_CONFIDENCE = 0.95
 EXACT_MATCH_CONFIDENCE = 0.95
 SENTENCE_NAME_CONFIDENCE = 0.8
@@ -117,36 +113,12 @@ class PersonResolver:
     def set_active_interlocutor(self, person_id: UUID | None) -> None:
         self._active_interlocutor_id = person_id
 
-    def _list_people(self) -> list[Person]:
-        """Return people for the current owner without creating a new owner on reads."""
-
-        with self.store.Session() as session:
-            owner_id = self.store._owner_user_id
-            if owner_id is not None:
-                owner = session.get(User, owner_id)
-                if owner is None:
-                    self.store._owner_user_id = None
-                    return []
-            else:
-                owner_id = session.scalar(select(User.id).order_by(User.created_at.asc()).limit(1))
-                if owner_id is None:
-                    return []
-                self.store._owner_user_id = owner_id
-
-            return list(
-                session.scalars(
-                    select(Person)
-                    .options(selectinload(Person.aliases))
-                    .where(Person.user_id == owner_id)
-                ).all()
-            )
-
     def _match_name_or_alias_in_sentence(self, query_text: str) -> ResolveResult | None:
         """Resolve a full display name or alias mentioned inside longer text."""
 
         matches: dict[UUID, tuple[str, float]] = {}
 
-        for person in self._list_people():
+        for person in self.store.list_people():
             display_name = person.display_name or person.first_name
             if display_name and _contains_phrase(query_text, display_name):
                 matches[person.id] = (display_name, SENTENCE_NAME_CONFIDENCE)
@@ -183,7 +155,7 @@ class PersonResolver:
 
         matches: list[tuple[UUID, str]] = []
 
-        for person in self._list_people():
+        for person in self.store.list_people():
             first_name = _normalize(person.first_name)
             if first_name and first_name in tokens:
                 matches.append((person.id, person.display_name or person.first_name))
@@ -203,15 +175,20 @@ class PersonResolver:
         return _ambiguous(candidates, confidence=AMBIGUOUS_CONFIDENCE)
 
     def resolve_person_from_query(self, query_text: str) -> ResolveResult:
-        """
-        Determine which person a user query is referencing.
-        Resolution happens in the following order:
-        1. Active interlocutor phrases included in ACTIVE_INTERLOCUTOR_PHRASES and PRONOUN_PATTERNS
-        2. Exact display-name and alias matches (case-insensitive)
-        3. Embedded full-name and alias mentions inside longer text
-        4. First-name matches (ambiguous if multiple people have the same name)
+        """Determine which person a user query is referencing.
 
-        This function resolves identity and does not retrieve profile data.
+        Resolution happens in the following priority order:
+
+        1. Exact display-name and alias matches (case-insensitive)
+        2. Embedded full-name and alias mentions inside longer text
+        3. First-name token matches (ambiguous if multiple people share a name)
+        4. Active interlocutor phrases / pronoun references
+
+        Name-based matching is attempted before pronoun or relative-reference
+        resolution so that queries like ``"What did Emily tell him?"`` resolve
+        to Emily rather than the active interlocutor.
+
+        This function resolves identity only and does not retrieve profile data.
 
         Args:
             query_text: Natural-language query that may contain a person
@@ -222,30 +199,35 @@ class PersonResolver:
             match is found, or is_ambiguous=True with candidates when
             multiple people match.
         """
+
         cleaned = _normalize(query_text)
         if not cleaned:
             return _no_match()
 
+        # 1. Exact display-name / alias
+        exact = self.store.resolve_person_by_name_or_alias(cleaned)
+        if exact is not None:
+            return _resolved(exact.id, confidence=EXACT_MATCH_CONFIDENCE)
+
+        # 2. Name or alias embedded in a longer sentence
+        sentence_match = self._match_name_or_alias_in_sentence(cleaned)
+        if sentence_match is not None:
+            return sentence_match
+
+        # 3. First-name token match
+        first_name_match = self._match_first_name(cleaned)
+        if first_name_match is not None:
+            return first_name_match
+
+        # 4. Relative / pronoun reference to the active interlocutor
         if _is_active_interlocutor_reference(cleaned):
             if self._active_interlocutor_id is not None:
                 return _resolved(
                     self._active_interlocutor_id,
                     confidence=ACTIVE_INTERLOCUTOR_CONFIDENCE,
                 )
-            return _no_match()
-
-        exact = self.store.resolve_person_by_name_or_alias(cleaned)
-        if exact is not None:
-            return _resolved(exact.id, confidence=EXACT_MATCH_CONFIDENCE)
-
-        sentence_match = self._match_name_or_alias_in_sentence(cleaned)
-        if sentence_match is not None:
-            return sentence_match
-
-        first_name_match = self._match_first_name(cleaned)
-        if first_name_match is not None:
-            return first_name_match
 
         return _no_match()
 
-        
+
+__all__ = ["PersonResolver"]

--- a/backend/app/schema/__init__.py
+++ b/backend/app/schema/__init__.py
@@ -1,6 +1,7 @@
 """Pydantic schemas used by the backend."""
 
 from .memory import EdgeOut, FactOut, PersonOut, PrefOut, ProfileContext, SummaryOut
+from .person_resolver import ResolveCandidate, ResolveResult
 from .user import UserFactRead, UserRead
 
 __all__ = [
@@ -9,6 +10,8 @@ __all__ = [
     "PersonOut",
     "PrefOut",
     "ProfileContext",
+    "ResolveCandidate",
+    "ResolveResult",
     "SummaryOut",
     "UserFactRead",
     "UserRead",

--- a/backend/app/schema/__init__.py
+++ b/backend/app/schema/__init__.py
@@ -1,6 +1,6 @@
 """Pydantic schemas used by the backend."""
 
-from .memory import EdgeOut, FactOut, PersonOut, PrefOut, ProfileContext, SummaryOut
+from .memory import EdgeOut, FactOut, PersonOut, ProfileContext, SummaryOut
 from .person_resolver import ResolveCandidate, ResolveResult
 from .user import UserFactRead, UserRead
 
@@ -8,7 +8,6 @@ __all__ = [
     "EdgeOut",
     "FactOut",
     "PersonOut",
-    "PrefOut",
     "ProfileContext",
     "ResolveCandidate",
     "ResolveResult",

--- a/backend/app/schema/memory.py
+++ b/backend/app/schema/memory.py
@@ -47,11 +47,10 @@ def _check_persona90(v: list[float]) -> list[float]:
 
 #input schemas
 
-#validates name length, cleans aliases, ensure case-insensitivity and persona length rule
+#validates name length and persona length rule
 class PersonIn(BaseModel):
     """Input for upsert_person()."""
     name: str = Field(..., min_length=1, max_length=200)
-    aliases: list[str] = Field(default_factory=list)
     face_key: Optional[str] = None
     voice_key: Optional[str] = None
     persona90: list[float] = Field(default_factory=list)
@@ -60,14 +59,6 @@ class PersonIn(BaseModel):
     @classmethod
     def validate_persona90(cls, v: list[float]) -> list[float]:
         return _check_persona90(v)
-
-    @field_validator("aliases")
-    @classmethod
-    def validate_aliases(cls, v: list[str]) -> list[str]:
-        cleaned = [a.strip() for a in v if a.strip()]
-        if len(cleaned) != len(set(a.lower() for a in cleaned)):
-            raise ValueError("aliases must be unique (case-insensitive)")
-        return cleaned
 
 
 class EpisodeIn(BaseModel):
@@ -109,19 +100,6 @@ class FactIn(BaseModel):
         if start and v and v < start:
             raise ValueError("valid_to must be >= valid_from")
         return v
-
-
-class PrefIn(BaseModel):
-    """Input for write_pref()."""
-    person_id: UUID
-    pref_text: str = Field(..., min_length=1)
-    confidence: float = 1.0
-    episode_id: Optional[UUID] = None
-
-    @field_validator("confidence")
-    @classmethod
-    def validate_confidence(cls, v: float) -> float:
-        return _check_confidence(v)
 
 
 class SummaryIn(BaseModel):
@@ -170,7 +148,6 @@ class PersonOut(BaseModel):
     face_key: Optional[str]
     voice_key: Optional[str]
     persona90: list[float]
-    aliases: list[str]
     created_at: str
     updated_at: str
 
@@ -183,14 +160,6 @@ class FactOut(BaseModel):
     episode_id: Optional[UUID]
     valid_from: Optional[str]
     valid_to: Optional[str]
-    created_at: str
-
-
-class PrefOut(BaseModel):
-    id: UUID
-    pref_text: str
-    confidence: float
-    episode_id: Optional[UUID]
     created_at: str
 
 
@@ -223,10 +192,9 @@ class ProfileContext(BaseModel):
     serialized into the text channel of the MemChunk (Eq. 2: p_t).
 
     Shape matches the issue spec:
-        { facts, prefs, summaries, edges_from, persona90 }
+        { facts, summaries, edges_from, persona90 }
     """
     facts: list[FactOut] = Field(default_factory=list)
-    prefs: list[PrefOut] = Field(default_factory=list)
     summaries: list[SummaryOut] = Field(default_factory=list)
     edges_from: list[EdgeOut] = Field(default_factory=list)
     persona90: list[float] = Field(default_factory=list)

--- a/backend/app/schema/person_resolver.py
+++ b/backend/app/schema/person_resolver.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _check_confidence(value: float) -> float:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"confidence must be in [0, 1], got {value}")
+    return value
+
+
+class ResolveCandidate(BaseModel):
+    """One possible person match returned by the query resolver."""
+
+    person_id: UUID
+    name: str = Field(..., min_length=1, max_length=200)
+    confidence: float
+
+    @field_validator("confidence")
+    @classmethod
+    def validate_confidence(cls, value: float) -> float:
+        return _check_confidence(value)
+
+
+class ResolveResult(BaseModel):
+    """Typed result returned by PersonResolver.resolve_person_from_query()."""
+
+    person_id: Optional[UUID] = None
+    confidence: float = 0.0
+    is_ambiguous: bool = False
+    candidates: list[ResolveCandidate] = Field(default_factory=list)
+
+    @field_validator("confidence")
+    @classmethod
+    def validate_confidence(cls, value: float) -> float:
+        return _check_confidence(value)
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "ResolveResult":
+        if self.person_id is not None and self.is_ambiguous:
+            raise ValueError("resolved result cannot be ambiguous")
+        if self.person_id is not None and self.candidates:
+            raise ValueError("resolved result should not include ambiguity candidates")
+        return self
+
+
+__all__ = ["ResolveCandidate", "ResolveResult"]

--- a/backend/app/schema/person_resolver.py
+++ b/backend/app/schema/person_resolver.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator, model_validator
-
-
-def _check_confidence(value: float) -> float:
-    if not 0.0 <= value <= 1.0:
-        raise ValueError(f"confidence must be in [0, 1], got {value}")
-    return value
+from pydantic import BaseModel, Field, model_validator
 
 
 class ResolveCandidate(BaseModel):
@@ -17,26 +11,15 @@ class ResolveCandidate(BaseModel):
 
     person_id: UUID
     name: str = Field(..., min_length=1, max_length=200)
-    confidence: float
-
-    @field_validator("confidence")
-    @classmethod
-    def validate_confidence(cls, value: float) -> float:
-        return _check_confidence(value)
+    hints: dict[str, list[str]] = Field(default_factory=dict)
 
 
 class ResolveResult(BaseModel):
     """Typed result returned by PersonResolver.resolve_person_from_query()."""
 
     person_id: Optional[UUID] = None
-    confidence: float = 0.0
     is_ambiguous: bool = False
     candidates: list[ResolveCandidate] = Field(default_factory=list)
-
-    @field_validator("confidence")
-    @classmethod
-    def validate_confidence(cls, value: float) -> float:
-        return _check_confidence(value)
 
     @model_validator(mode="after")
     def validate_consistency(self) -> "ResolveResult":

--- a/backend/scripts/seed_memory_store.py
+++ b/backend/scripts/seed_memory_store.py
@@ -4,26 +4,61 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import get_settings
+from app.core.database import Base
 from app.crud.memory_store import MemoryStore
+from app.models.user import User
+
+
+def _get_or_create_seed_owner(db_url: str):
+    """Return the first user's UUID, creating a seed user if none exists."""
+
+    engine = create_engine(db_url, future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+    with Session() as session:
+        owner = session.scalar(select(User).order_by(User.created_at.asc()).limit(1))
+        if owner is None:
+            with session.begin():
+                owner = User(
+                    first_name="Seed",
+                    last_name="Owner",
+                    display_name="Seed Owner",
+                    username="seed-owner",
+                )
+                session.add(owner)
+                session.flush()
+                print(f"Created seed owner user id={owner.id}")
+        else:
+            print(f"Using existing owner user id={owner.id}")
+        owner_id = owner.id
+
+    engine.dispose()
+    return owner_id
 
 
 def main() -> None:
     """Seed the configured database with a minimal memory dataset."""
 
-    store = MemoryStore()
-    store.initialize()
+    settings = get_settings()
+    owner_id = _get_or_create_seed_owner(settings.database_url)
+
+    store = MemoryStore(owner_user_id=owner_id)
+    store.initialize(create_schema=False)
 
     try:
         emily = store.upsert_person(
             name="Emily Chen",
-            aliases=["Em", "Dr. Chen"],
             face_key="face_emily_demo",
             voice_key="voice_emily_demo",
             persona90=[0.5] * 90,
         )
         john = store.upsert_person(
             name="John Rivera",
-            aliases=["Johnny"],
             face_key="face_john_demo",
         )
 

--- a/backend/tests/test_memory_store.py
+++ b/backend/tests/test_memory_store.py
@@ -21,28 +21,44 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.crud.memory_store import MemoryStore
-from app.models.memory import Edge, Pref, Summary
+from app.models.memory import Edge, Summary
 from app.models.person import PersonFact
 from app.models.user import User
+
+
+def _make_store() -> MemoryStore:
+    """Create an initialized MemoryStore with a pre-seeded owner user."""
+
+    owner_id = uuid4()
+    store = MemoryStore("sqlite+pysqlite:///:memory:", owner_user_id=owner_id)
+    store.initialize()
+    with store.Session() as session:
+        with session.begin():
+            session.add(User(
+                id=owner_id,
+                first_name="Test",
+                last_name="Owner",
+                display_name="Test Owner",
+                username="test-owner",
+            ))
+    return store
 
 
 @pytest.fixture
 def store():
     """Fresh in-memory database for each test."""
 
-    s = MemoryStore("sqlite+pysqlite:///:memory:")
-    s.initialize()
+    s = _make_store()
     yield s
     s.close()
 
 
 @pytest.fixture
 def emily(store: MemoryStore):
-    """Create a test person named Emily with aliases."""
+    """Create a test person named Emily."""
 
     return store.upsert_person(
         name="Emily Chen",
-        aliases=["Em", "Dr. Chen"],
         face_key="face_emily_001",
         voice_key="voice_emily_001",
         persona90=[0.5] * 90,
@@ -55,7 +71,6 @@ def john(store: MemoryStore):
 
     return store.upsert_person(
         name="John Rivera",
-        aliases=["Johnny"],
         face_key="face_john_001",
         voice_key="voice_john_001",
     )
@@ -68,59 +83,22 @@ class TestUpsertPerson:
         assert emily.face_key == "face_emily_001"
         assert emily.voice_key == "voice_emily_001"
         assert len(emily.persona90) == 90
-        assert sorted(emily.aliases) == sorted(["Em", "Dr. Chen"])
 
     def test_upsert_updates_existing(self, store, emily):
         updated = store.upsert_person(
             name="Emily Chen",
-            aliases=["Em", "Emmy"],
             face_key="face_emily_002",
         )
         assert updated.id == emily.id
         assert updated.face_key == "face_emily_002"
-        assert "Emmy" in updated.aliases
-        assert "Dr. Chen" not in updated.aliases
-
-    def test_default_owner_user_created(self, store, emily):
-        with store.Session() as session:
-            users = session.query(User).all()
-        assert len(users) == 1
-        assert users[0].username == "memory-store-owner"
 
     def test_persona90_must_be_0_or_90(self, store):
         with pytest.raises(ValueError, match="0 or 90"):
-            store.upsert_person(name="Bad Person", aliases=[], persona90=[1.0] * 50)
+            store.upsert_person(name="Bad Person", persona90=[1.0] * 50)
 
     def test_empty_name_rejected(self, store):
         with pytest.raises(ValueError):
-            store.upsert_person(name="", aliases=[])
-
-    def test_duplicate_aliases_rejected(self, store):
-        with pytest.raises(ValueError, match="unique"):
-            store.upsert_person(name="X", aliases=["a", "A"])
-
-
-class TestResolvePerson:
-    def test_resolve_by_name(self, store, emily):
-        found = store.resolve_person_by_name_or_alias("Emily Chen")
-        assert found is not None
-        assert found.id == emily.id
-
-    def test_resolve_by_alias(self, store, emily):
-        found = store.resolve_person_by_name_or_alias("Em")
-        assert found is not None
-        assert found.id == emily.id
-
-    def test_resolve_case_insensitive(self, store, emily):
-        found = store.resolve_person_by_name_or_alias("dr. chen")
-        assert found is not None
-        assert found.id == emily.id
-
-    def test_resolve_unknown_returns_none(self, store, emily):
-        assert store.resolve_person_by_name_or_alias("Nobody") is None
-
-    def test_resolve_empty_string_returns_none(self, store, emily):
-        assert store.resolve_person_by_name_or_alias("  ") is None
+            store.upsert_person(name="")
 
 
 class TestWriteEpisode:
@@ -192,19 +170,6 @@ class TestWriteFact:
             store.write_fact(person_id=uuid4(), fact_text="test")
 
 
-class TestWritePref:
-    def test_write_pref(self, store, emily):
-        pid = store.write_pref(
-            person_id=emily.id,
-            pref_text="energy: high",
-        )
-        assert pid
-
-        profile = store.get_profile_context(emily.id)
-        assert len(profile.prefs) == 1
-        assert profile.prefs[0].pref_text == "energy: high"
-
-
 class TestWriteSummary:
     def test_write_summary(self, store, emily):
         sid = store.write_summary(
@@ -273,14 +238,6 @@ class TestProfileContext:
             fact_text="the user has a pet dog named Max",
             confidence=0.8,
         )
-        store.write_pref(
-            person_id=emily.id,
-            pref_text="energy: high",
-        )
-        store.write_pref(
-            person_id=emily.id,
-            pref_text="sensitivity: low",
-        )
         store.write_summary(
             person_id=emily.id,
             summary_text="2024-05-13: the user asked about swimming.",
@@ -298,7 +255,6 @@ class TestProfileContext:
         profile = store.get_profile_context(emily.id)
 
         assert len(profile.facts) == 2
-        assert len(profile.prefs) == 2
         assert len(profile.summaries) == 1
         assert len(profile.edges_from) == 1
         assert len(profile.persona90) == 90
@@ -310,7 +266,6 @@ class TestProfileContext:
     def test_empty_profile(self, store, emily):
         profile = store.get_profile_context(emily.id)
         assert profile.facts == []
-        assert profile.prefs == []
         assert profile.summaries == []
         assert profile.edges_from == []
         assert len(profile.persona90) == 90
@@ -322,12 +277,12 @@ class TestProfileContext:
 
 class TestLifecycleAndErrors:
     def test_session_access_before_initialize_raises(self):
-        store = MemoryStore("sqlite+pysqlite:///:memory:")
+        store = MemoryStore("sqlite+pysqlite:///:memory:", owner_user_id=uuid4())
         with pytest.raises(RuntimeError, match="not initialized"):
             _ = store.Session
 
     def test_close_is_idempotent(self):
-        store = MemoryStore("sqlite+pysqlite:///:memory:")
+        store = MemoryStore("sqlite+pysqlite:///:memory:", owner_user_id=uuid4())
         store.close()
         store.initialize()
         store.close()
@@ -350,14 +305,6 @@ class TestLifecycleAndErrors:
                 episode_id=uuid4(),
             )
 
-    def test_write_pref_bad_episode_rejected(self, store, emily):
-        with pytest.raises(ValueError, match="Episode id=.* not found"):
-            store.write_pref(
-                person_id=emily.id,
-                pref_text="pref",
-                episode_id=uuid4(),
-            )
-
     def test_write_summary_bad_episode_rejected(self, store, emily):
         with pytest.raises(ValueError, match="Episode id=.* not found"):
             store.write_summary(
@@ -375,11 +322,6 @@ class TestLifecycleAndErrors:
                 episode_id=uuid4(),
             )
 
-    def test_upsert_person_alias_conflict_surfaces_value_error(self, store):
-        store.upsert_person(name="Alice Smith", aliases=["same-alias"])
-        with pytest.raises(ValueError, match="Unable to upsert person"):
-            store.upsert_person(name="Bob Jones", aliases=["same-alias"])
-
 
 class TestOrderingAndSerialization:
     def test_profile_context_returns_desc_created_order(self, store, emily, john):
@@ -387,9 +329,6 @@ class TestOrderingAndSerialization:
 
         older_fact = store.write_fact(person_id=emily.id, fact_text="old fact")
         newer_fact = store.write_fact(person_id=emily.id, fact_text="new fact")
-
-        older_pref = store.write_pref(person_id=emily.id, pref_text="old pref")
-        newer_pref = store.write_pref(person_id=emily.id, pref_text="new pref")
 
         older_summary = store.write_summary(person_id=emily.id, summary_text="old summary")
         newer_summary = store.write_summary(person_id=emily.id, summary_text="new summary")
@@ -402,9 +341,6 @@ class TestOrderingAndSerialization:
                 session.get(PersonFact, older_fact).created_at = now - timedelta(minutes=4)
                 session.get(PersonFact, newer_fact).created_at = now - timedelta(minutes=1)
 
-                session.get(Pref, older_pref).created_at = now - timedelta(minutes=5)
-                session.get(Pref, newer_pref).created_at = now - timedelta(minutes=2)
-
                 session.get(Summary, older_summary).created_at = now - timedelta(minutes=6)
                 session.get(Summary, newer_summary).created_at = now - timedelta(minutes=3)
 
@@ -415,8 +351,6 @@ class TestOrderingAndSerialization:
 
         assert profile.facts[0].fact_text == "new fact"
         assert profile.facts[1].fact_text == "old fact"
-        assert profile.prefs[0].pref_text == "new pref"
-        assert profile.prefs[1].pref_text == "old pref"
         assert profile.summaries[0].summary_text == "new summary"
         assert profile.summaries[1].summary_text == "old summary"
         assert profile.edges_from[0].relation == "new-rel"

--- a/backend/tests/test_person_resolver.py
+++ b/backend/tests/test_person_resolver.py
@@ -1,0 +1,350 @@
+"""
+Tests for the person_resolver module.
+
+Issue #2 Acceptance Criteria:
+  - Query referencing current interlocutor resolves correctly
+  - Query referencing known name resolves correctly
+  - Alias resolution works
+  - Ambiguous queries result in requests for further information
+  - No console errors
+  - Module only resolves identity (no retrieval)
+"""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+from uuid import UUID, uuid4
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.crud.memory_store import MemoryStore
+
+# The module under test -- will fail until person_resolver.py is created.
+from app.crud.person_resolver import PersonResolver
+
+
+# ── Fixtures ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store():
+    """Fresh in-memory database for each test."""
+    s = MemoryStore("sqlite+pysqlite:///:memory:")
+    s.initialize()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def resolver(store: MemoryStore):
+    """PersonResolver backed by the in-memory store."""
+    return PersonResolver(store)
+
+
+@pytest.fixture
+def emily(store: MemoryStore):
+    """Person: Emily Chen with aliases Em, Dr. Chen."""
+    return store.upsert_person(
+        name="Emily Chen",
+        aliases=["Em", "Dr. Chen"],
+        face_key="face_emily_001",
+        voice_key="voice_emily_001",
+        persona90=[0.5] * 90,
+    )
+
+
+@pytest.fixture
+def john(store: MemoryStore):
+    """Person: John Rivera with alias Johnny."""
+    return store.upsert_person(
+        name="John Rivera",
+        aliases=["Johnny"],
+        face_key="face_john_001",
+        voice_key="voice_john_001",
+    )
+
+
+@pytest.fixture
+def sarah(store: MemoryStore):
+    """Person: Sarah Martinez with alias S."""
+    return store.upsert_person(
+        name="Sarah Martinez",
+        aliases=["S"],
+    )
+
+
+@pytest.fixture
+def recent_episode(store, emily, john):
+    """Episode where Emily and John participated recently."""
+    now = datetime.now(timezone.utc)
+    return store.write_episode(
+        time_start=now - timedelta(minutes=10),
+        time_end=now,
+        transcript="Emily: Hi John!\nJohn: Hey Emily!",
+        summary="Casual greeting between Emily and John.",
+        participants=[emily.id, john.id],
+    )
+
+
+# ── Canonical name resolution ───────────────────────────────
+
+
+class TestResolveByName:
+    """Query referencing known name resolves correctly."""
+
+    def test_exact_name_match(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert result.person_id == emily.id
+
+    def test_case_insensitive_name(self, resolver, emily):
+        result = resolver.resolve_person_from_query("emily chen")
+        assert result.person_id == emily.id
+
+    def test_mixed_case_name(self, resolver, emily):
+        result = resolver.resolve_person_from_query("EMILY CHEN")
+        assert result.person_id == emily.id
+
+    def test_name_embedded_in_sentence(self, resolver, emily):
+        """Extract name from a natural-language query."""
+        result = resolver.resolve_person_from_query("What does Emily Chen like?")
+        assert result.person_id == emily.id
+
+    def test_first_name_only_when_unambiguous(self, resolver, emily):
+        """First name alone should resolve when only one person matches."""
+        result = resolver.resolve_person_from_query("Emily")
+        assert result.person_id == emily.id
+
+    def test_unknown_name_returns_no_match(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Zara Thompson")
+        assert result.person_id is None
+        assert result.is_ambiguous is False
+
+
+# ── Alias resolution ────────────────────────────────────────
+
+
+class TestResolveByAlias:
+    """Alias resolution works."""
+
+    def test_alias_exact(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Em")
+        assert result.person_id == emily.id
+
+    def test_alias_case_insensitive(self, resolver, emily):
+        result = resolver.resolve_person_from_query("dr. chen")
+        assert result.person_id == emily.id
+
+    def test_alias_in_sentence(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Tell me about Dr. Chen")
+        assert result.person_id == emily.id
+
+    def test_alias_for_second_person(self, resolver, john):
+        result = resolver.resolve_person_from_query("Johnny")
+        assert result.person_id == john.id
+
+
+# ── Active interlocutor resolution ──────────────────────────
+
+
+class TestResolveActiveInterlocutor:
+    """Query referencing current interlocutor resolves correctly."""
+
+    def test_the_person_i_was_talking_to(self, resolver, emily, recent_episode):
+        resolver.set_active_interlocutor(emily.id)
+        result = resolver.resolve_person_from_query(
+            "the person I was talking to"
+        )
+        assert result.person_id == emily.id
+
+    def test_this_person(self, resolver, emily, recent_episode):
+        resolver.set_active_interlocutor(emily.id)
+        result = resolver.resolve_person_from_query("this person")
+        assert result.person_id == emily.id
+
+    def test_them(self, resolver, emily, recent_episode):
+        resolver.set_active_interlocutor(emily.id)
+        result = resolver.resolve_person_from_query("What do they like?")
+        assert result.person_id == emily.id
+
+    def test_current_speaker(self, resolver, john, recent_episode):
+        resolver.set_active_interlocutor(john.id)
+        result = resolver.resolve_person_from_query(
+            "the person I'm speaking with"
+        )
+        assert result.person_id == john.id
+
+    def test_no_active_interlocutor_set(self, resolver):
+        """Relative reference without an active interlocutor returns no match."""
+        result = resolver.resolve_person_from_query(
+            "the person I was talking to"
+        )
+        assert result.person_id is None
+
+
+# ── Ambiguous queries ───────────────────────────────────────
+
+
+class TestAmbiguousQueries:
+    """Ambiguous queries result in requests for further information."""
+
+    def test_shared_first_name_is_ambiguous(self, store, resolver):
+        """Two people named 'Alex' should produce an ambiguous result."""
+        store.upsert_person(name="Alex Smith", aliases=[])
+        store.upsert_person(name="Alex Johnson", aliases=[])
+        result = resolver.resolve_person_from_query("Alex")
+        assert result.is_ambiguous is True
+        assert result.person_id is None
+        assert len(result.candidates) >= 2
+
+    def test_ambiguous_result_contains_candidate_ids(self, store, resolver):
+        p1 = store.upsert_person(name="Jordan Lee", aliases=["JL"])
+        p2 = store.upsert_person(name="Jordan Park", aliases=["JP"])
+        result = resolver.resolve_person_from_query("Jordan")
+        assert result.is_ambiguous is True
+        candidate_ids = {c.person_id for c in result.candidates}
+        assert p1.id in candidate_ids
+        assert p2.id in candidate_ids
+
+    def test_full_name_disambiguates(self, store, resolver):
+        """Using the full name should not be ambiguous."""
+        store.upsert_person(name="Jordan Lee", aliases=[])
+        store.upsert_person(name="Jordan Park", aliases=[])
+        result = resolver.resolve_person_from_query("Jordan Lee")
+        assert result.is_ambiguous is False
+        assert result.person_id is not None
+
+    def test_completely_vague_query(self, resolver, emily, john):
+        """A query with no person reference at all."""
+        result = resolver.resolve_person_from_query("What's the weather?")
+        assert result.person_id is None
+        assert result.is_ambiguous is False
+
+
+# ── Confidence threshold ────────────────────────────────────
+
+
+class TestConfidenceThreshold:
+    """Return resolved person_id only if above certain confidence threshold."""
+
+    def test_exact_match_above_threshold(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert result.confidence >= 0.8
+
+    def test_alias_match_above_threshold(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Em")
+        assert result.confidence >= 0.5
+
+    def test_no_match_confidence_is_zero(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Nonexistent Person")
+        assert result.confidence == 0.0
+
+    def test_vague_reference_low_confidence(self, resolver, emily, john):
+        """A vague query should not produce high confidence."""
+        result = resolver.resolve_person_from_query("someone")
+        assert result.confidence < 0.5
+
+
+# ── Edge cases and input validation ─────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_string(self, resolver):
+        result = resolver.resolve_person_from_query("")
+        assert result.person_id is None
+
+    def test_whitespace_only(self, resolver):
+        result = resolver.resolve_person_from_query("   ")
+        assert result.person_id is None
+
+    def test_special_characters(self, resolver, emily):
+        result = resolver.resolve_person_from_query("@#$%^&*()")
+        assert result.person_id is None
+
+    def test_very_long_query(self, resolver, emily):
+        long_text = "tell me about " + "Emily Chen " * 100
+        result = resolver.resolve_person_from_query(long_text)
+        assert result.person_id == emily.id
+
+    def test_name_with_extra_whitespace(self, resolver, emily):
+        result = resolver.resolve_person_from_query("  Emily   Chen  ")
+        assert result.person_id == emily.id
+
+
+# ── Result shape ────────────────────────────────────────────
+
+
+class TestResultShape:
+    """Verify the resolver returns a well-typed result object."""
+
+    def test_resolved_result_has_person_id(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert isinstance(result.person_id, UUID)
+
+    def test_result_has_confidence(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert isinstance(result.confidence, float)
+        assert 0.0 <= result.confidence <= 1.0
+
+    def test_result_has_is_ambiguous(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert isinstance(result.is_ambiguous, bool)
+
+    def test_result_has_candidates_list(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert isinstance(result.candidates, list)
+
+    def test_unresolved_result_shape(self, resolver):
+        result = resolver.resolve_person_from_query("Nobody")
+        assert result.person_id is None
+        assert result.confidence == 0.0
+        assert result.is_ambiguous is False
+        assert result.candidates == []
+
+
+# ── Identity-only boundary ──────────────────────────────────
+
+
+class TestIdentityOnlyBoundary:
+    """Module only resolves identity; no retrieval should occur."""
+
+    def test_resolve_does_not_return_facts(self, resolver, store, emily):
+        store.write_fact(person_id=emily.id, fact_text="Likes cats")
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert not hasattr(result, "facts")
+
+    def test_resolve_does_not_return_profile(self, resolver, emily):
+        result = resolver.resolve_person_from_query("Emily Chen")
+        assert not hasattr(result, "profile")
+        assert not hasattr(result, "prefs")
+        assert not hasattr(result, "summaries")
+
+
+# ── Multiple-person scenarios ───────────────────────────────
+
+
+class TestMultiplePeople:
+    def test_resolve_different_people_independently(self, resolver, emily, john):
+        r1 = resolver.resolve_person_from_query("Emily Chen")
+        r2 = resolver.resolve_person_from_query("John Rivera")
+        assert r1.person_id == emily.id
+        assert r2.person_id == john.id
+        assert r1.person_id != r2.person_id
+
+    def test_resolve_by_alias_when_multiple_people_exist(
+        self, resolver, emily, john, sarah
+    ):
+        result = resolver.resolve_person_from_query("Johnny")
+        assert result.person_id == john.id
+
+    def test_switching_active_interlocutor(self, resolver, emily, john, recent_episode):
+        resolver.set_active_interlocutor(emily.id)
+        r1 = resolver.resolve_person_from_query("this person")
+        assert r1.person_id == emily.id
+
+        resolver.set_active_interlocutor(john.id)
+        r2 = resolver.resolve_person_from_query("this person")
+        assert r2.person_id == john.id

--- a/backend/tests/test_person_resolver.py
+++ b/backend/tests/test_person_resolver.py
@@ -1,16 +1,12 @@
 """
 Tests for the person_resolver module.
 
-Issue #2 Acceptance Criteria:
-  - Query referencing current interlocutor resolves correctly
+Issue #8 Acceptance Criteria:
   - Query referencing known name resolves correctly
-  - Alias resolution works
-  - Ambiguous queries result in requests for further information
+  - Ambiguous queries return candidates with fact hints
   - No console errors
-  - Module only resolves identity (no retrieval)
 """
 
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
 from uuid import UUID, uuid4
@@ -22,8 +18,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.crud.memory_store import MemoryStore
-
-# The module under test -- will fail until person_resolver.py is created.
+from app.models.user import User
 from app.crud.person_resolver import PersonResolver
 
 
@@ -33,8 +28,18 @@ from app.crud.person_resolver import PersonResolver
 @pytest.fixture
 def store():
     """Fresh in-memory database for each test."""
-    s = MemoryStore("sqlite+pysqlite:///:memory:")
+    owner_id = uuid4()
+    s = MemoryStore("sqlite+pysqlite:///:memory:", owner_user_id=owner_id)
     s.initialize()
+    with s.Session() as session:
+        with session.begin():
+            session.add(User(
+                id=owner_id,
+                first_name="Test",
+                last_name="Owner",
+                display_name="Test Owner",
+                username="test-owner",
+            ))
     yield s
     s.close()
 
@@ -47,10 +52,9 @@ def resolver(store: MemoryStore):
 
 @pytest.fixture
 def emily(store: MemoryStore):
-    """Person: Emily Chen with aliases Em, Dr. Chen."""
+    """Person: Emily Chen."""
     return store.upsert_person(
         name="Emily Chen",
-        aliases=["Em", "Dr. Chen"],
         face_key="face_emily_001",
         voice_key="voice_emily_001",
         persona90=[0.5] * 90,
@@ -59,10 +63,9 @@ def emily(store: MemoryStore):
 
 @pytest.fixture
 def john(store: MemoryStore):
-    """Person: John Rivera with alias Johnny."""
+    """Person: John Rivera."""
     return store.upsert_person(
         name="John Rivera",
-        aliases=["Johnny"],
         face_key="face_john_001",
         voice_key="voice_john_001",
     )
@@ -70,27 +73,13 @@ def john(store: MemoryStore):
 
 @pytest.fixture
 def sarah(store: MemoryStore):
-    """Person: Sarah Martinez with alias S."""
+    """Person: Sarah Martinez."""
     return store.upsert_person(
         name="Sarah Martinez",
-        aliases=["S"],
     )
 
 
-@pytest.fixture
-def recent_episode(store, emily, john):
-    """Episode where Emily and John participated recently."""
-    now = datetime.now(timezone.utc)
-    return store.write_episode(
-        time_start=now - timedelta(minutes=10),
-        time_end=now,
-        transcript="Emily: Hi John!\nJohn: Hey Emily!",
-        summary="Casual greeting between Emily and John.",
-        participants=[emily.id, john.id],
-    )
-
-
-# ── Canonical name resolution ───────────────────────────────
+# ── Name resolution ─────────────────────────────────────────
 
 
 class TestResolveByName:
@@ -109,7 +98,6 @@ class TestResolveByName:
         assert result.person_id == emily.id
 
     def test_name_embedded_in_sentence(self, resolver, emily):
-        """Extract name from a natural-language query."""
         result = resolver.resolve_person_from_query("What does Emily Chen like?")
         assert result.person_id == emily.id
 
@@ -124,85 +112,23 @@ class TestResolveByName:
         assert result.is_ambiguous is False
 
 
-# ── Alias resolution ────────────────────────────────────────
-
-
-class TestResolveByAlias:
-    """Alias resolution works."""
-
-    def test_alias_exact(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Em")
-        assert result.person_id == emily.id
-
-    def test_alias_case_insensitive(self, resolver, emily):
-        result = resolver.resolve_person_from_query("dr. chen")
-        assert result.person_id == emily.id
-
-    def test_alias_in_sentence(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Tell me about Dr. Chen")
-        assert result.person_id == emily.id
-
-    def test_alias_for_second_person(self, resolver, john):
-        result = resolver.resolve_person_from_query("Johnny")
-        assert result.person_id == john.id
-
-
-# ── Active interlocutor resolution ──────────────────────────
-
-
-class TestResolveActiveInterlocutor:
-    """Query referencing current interlocutor resolves correctly."""
-
-    def test_the_person_i_was_talking_to(self, resolver, emily, recent_episode):
-        resolver.set_active_interlocutor(emily.id)
-        result = resolver.resolve_person_from_query(
-            "the person I was talking to"
-        )
-        assert result.person_id == emily.id
-
-    def test_this_person(self, resolver, emily, recent_episode):
-        resolver.set_active_interlocutor(emily.id)
-        result = resolver.resolve_person_from_query("this person")
-        assert result.person_id == emily.id
-
-    def test_them(self, resolver, emily, recent_episode):
-        resolver.set_active_interlocutor(emily.id)
-        result = resolver.resolve_person_from_query("What do they like?")
-        assert result.person_id == emily.id
-
-    def test_current_speaker(self, resolver, john, recent_episode):
-        resolver.set_active_interlocutor(john.id)
-        result = resolver.resolve_person_from_query(
-            "the person I'm speaking with"
-        )
-        assert result.person_id == john.id
-
-    def test_no_active_interlocutor_set(self, resolver):
-        """Relative reference without an active interlocutor returns no match."""
-        result = resolver.resolve_person_from_query(
-            "the person I was talking to"
-        )
-        assert result.person_id is None
-
-
 # ── Ambiguous queries ───────────────────────────────────────
 
 
 class TestAmbiguousQueries:
-    """Ambiguous queries result in requests for further information."""
+    """Ambiguous queries return candidates for disambiguation."""
 
     def test_shared_first_name_is_ambiguous(self, store, resolver):
-        """Two people named 'Alex' should produce an ambiguous result."""
-        store.upsert_person(name="Alex Smith", aliases=[])
-        store.upsert_person(name="Alex Johnson", aliases=[])
+        store.upsert_person(name="Alex Smith")
+        store.upsert_person(name="Alex Johnson")
         result = resolver.resolve_person_from_query("Alex")
         assert result.is_ambiguous is True
         assert result.person_id is None
         assert len(result.candidates) >= 2
 
     def test_ambiguous_result_contains_candidate_ids(self, store, resolver):
-        p1 = store.upsert_person(name="Jordan Lee", aliases=["JL"])
-        p2 = store.upsert_person(name="Jordan Park", aliases=["JP"])
+        p1 = store.upsert_person(name="Jordan Lee")
+        p2 = store.upsert_person(name="Jordan Park")
         result = resolver.resolve_person_from_query("Jordan")
         assert result.is_ambiguous is True
         candidate_ids = {c.person_id for c in result.candidates}
@@ -210,45 +136,65 @@ class TestAmbiguousQueries:
         assert p2.id in candidate_ids
 
     def test_full_name_disambiguates(self, store, resolver):
-        """Using the full name should not be ambiguous."""
-        store.upsert_person(name="Jordan Lee", aliases=[])
-        store.upsert_person(name="Jordan Park", aliases=[])
+        store.upsert_person(name="Jordan Lee")
+        store.upsert_person(name="Jordan Park")
         result = resolver.resolve_person_from_query("Jordan Lee")
         assert result.is_ambiguous is False
         assert result.person_id is not None
 
     def test_completely_vague_query(self, resolver, emily, john):
-        """A query with no person reference at all."""
         result = resolver.resolve_person_from_query("What's the weather?")
         assert result.person_id is None
         assert result.is_ambiguous is False
 
 
-# ── Confidence threshold ────────────────────────────────────
+# ── Disambiguation hints ────────────────────────────────────
 
 
-class TestConfidenceThreshold:
-    """Return resolved person_id only if above certain confidence threshold."""
+class TestAmbiguousWithHints:
+    """Ambiguous results include categorized fact hints."""
 
-    def test_exact_match_above_threshold(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Emily Chen")
-        assert result.confidence >= 0.8
+    def test_hints_populated_from_facts(self, store, resolver):
+        p1 = store.upsert_person(name="Alex Smith")
+        p2 = store.upsert_person(name="Alex Johnson")
+        store.write_fact(p1.id, "tall with brown hair", fact_category="visual_descriptor")
+        store.write_fact(p1.id, "works at Google", fact_category="affiliation")
+        store.write_fact(p2.id, "short with glasses", fact_category="visual_descriptor")
+        store.write_fact(p2.id, "likes tennis", fact_category="hobby")
 
-    def test_alias_match_above_threshold(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Em")
-        assert result.confidence >= 0.5
+        result = resolver.resolve_person_from_query("Alex")
+        assert result.is_ambiguous is True
 
-    def test_no_match_confidence_is_zero(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Nonexistent Person")
-        assert result.confidence == 0.0
+        by_name = {c.name: c for c in result.candidates}
+        smith = by_name["Alex Smith"]
+        johnson = by_name["Alex Johnson"]
 
-    def test_vague_reference_low_confidence(self, resolver, emily, john):
-        """A vague query should not produce high confidence."""
-        result = resolver.resolve_person_from_query("someone")
-        assert result.confidence < 0.5
+        assert "tall with brown hair" in smith.hints.get("visual_descriptor", [])
+        assert "works at Google" in smith.hints.get("affiliation", [])
+        assert "short with glasses" in johnson.hints.get("visual_descriptor", [])
+        assert "likes tennis" in johnson.hints.get("hobby", [])
+
+    def test_hints_empty_when_no_facts(self, store, resolver):
+        store.upsert_person(name="Alex Smith")
+        store.upsert_person(name="Alex Johnson")
+        result = resolver.resolve_person_from_query("Alex")
+        assert result.is_ambiguous is True
+        for candidate in result.candidates:
+            assert candidate.hints == {}
+
+    def test_hints_only_include_categorized_facts(self, store, resolver):
+        p1 = store.upsert_person(name="Alex Smith")
+        store.upsert_person(name="Alex Johnson")
+        store.write_fact(p1.id, "uncategorized fact")
+        store.write_fact(p1.id, "plays guitar", fact_category="hobby")
+
+        result = resolver.resolve_person_from_query("Alex")
+        smith = next(c for c in result.candidates if c.name == "Alex Smith")
+        assert "plays guitar" in smith.hints.get("hobby", [])
+        assert not any("uncategorized" in t for texts in smith.hints.values() for t in texts)
 
 
-# ── Edge cases and input validation ─────────────────────────
+# ── Edge cases ──────────────────────────────────────────────
 
 
 class TestEdgeCases:
@@ -278,16 +224,9 @@ class TestEdgeCases:
 
 
 class TestResultShape:
-    """Verify the resolver returns a well-typed result object."""
-
     def test_resolved_result_has_person_id(self, resolver, emily):
         result = resolver.resolve_person_from_query("Emily Chen")
         assert isinstance(result.person_id, UUID)
-
-    def test_result_has_confidence(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Emily Chen")
-        assert isinstance(result.confidence, float)
-        assert 0.0 <= result.confidence <= 1.0
 
     def test_result_has_is_ambiguous(self, resolver, emily):
         result = resolver.resolve_person_from_query("Emily Chen")
@@ -300,27 +239,8 @@ class TestResultShape:
     def test_unresolved_result_shape(self, resolver):
         result = resolver.resolve_person_from_query("Nobody")
         assert result.person_id is None
-        assert result.confidence == 0.0
         assert result.is_ambiguous is False
         assert result.candidates == []
-
-
-# ── Identity-only boundary ──────────────────────────────────
-
-
-class TestIdentityOnlyBoundary:
-    """Module only resolves identity; no retrieval should occur."""
-
-    def test_resolve_does_not_return_facts(self, resolver, store, emily):
-        store.write_fact(person_id=emily.id, fact_text="Likes cats")
-        result = resolver.resolve_person_from_query("Emily Chen")
-        assert not hasattr(result, "facts")
-
-    def test_resolve_does_not_return_profile(self, resolver, emily):
-        result = resolver.resolve_person_from_query("Emily Chen")
-        assert not hasattr(result, "profile")
-        assert not hasattr(result, "prefs")
-        assert not hasattr(result, "summaries")
 
 
 # ── Multiple-person scenarios ───────────────────────────────
@@ -333,18 +253,3 @@ class TestMultiplePeople:
         assert r1.person_id == emily.id
         assert r2.person_id == john.id
         assert r1.person_id != r2.person_id
-
-    def test_resolve_by_alias_when_multiple_people_exist(
-        self, resolver, emily, john, sarah
-    ):
-        result = resolver.resolve_person_from_query("Johnny")
-        assert result.person_id == john.id
-
-    def test_switching_active_interlocutor(self, resolver, emily, john, recent_episode):
-        resolver.set_active_interlocutor(emily.id)
-        r1 = resolver.resolve_person_from_query("this person")
-        assert r1.person_id == emily.id
-
-        resolver.set_active_interlocutor(john.id)
-        r2 = resolver.resolve_person_from_query("this person")
-        assert r2.person_id == john.id


### PR DESCRIPTION
## Summary
- **PersonResolver**: Simplified to 2-pass name matching (display-name, then first-name fallback) with 0/1/N branching per issue #8 comment. Ambiguous results include categorized fact hints (`visual_descriptor`, `affiliation`, `hobby`) for GPT 5 nano disambiguation.
- **MemoryStore**: `owner_user_id` now required at construction. Removed alias infrastructure, `write_pref`, `PrefIn`/`PrefOut`, prefs from `ProfileContext`. Added `get_disambiguation_hints()` and `get_user_facts()`. Renamed `resolve_person_by_name_or_alias` → `resolve_person_by_name`.
- **Schemas**: Removed confidence from `ResolveResult`/`ResolveCandidate`. Added `hints: dict[str, list[str]]` to `ResolveCandidate`.

## Breaking changes for ingestion service (PR #18)
The ingestion service calls `resolve_person_by_name_or_alias()` (renamed to `resolve_person_by_name()`) and passes `aliases=` to `upsert_person()` (param removed). A follow-up PR is needed to update `conversation_ingestion.py`. These are call-site renames, not logic changes.

## ORM model cleanup (separate PR)
PersonFact ORM still has `source`, `confidence`, `valid_from`, `valid_to` columns removed from DB_STRUCTURE.md. User ORM still has `oauth_provider`, `oauth_subject`, `preferences`. Alias/Pref ORM models still exist. These require migrations and should be a separate PR.

## Test plan
- [ ] `python -m pytest backend/tests/test_person_resolver.py -v` (23 tests)
- [ ] `python -m pytest backend/tests/test_memory_store.py -v` (26 tests)
- [ ] Update ingestion service call sites before merging
